### PR TITLE
refactor(win32): Use native pointer info instead of WinRT

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Event.kt
@@ -73,7 +73,7 @@ public sealed class Event {
     ) : Event()
 
     public data class PointerDown(
-        val button: PointerButton,
+        val button: PointerButtons,
         val locationInWindow: LogicalPoint,
         val state: PointerState,
         val timestamp: Timestamp,
@@ -94,7 +94,7 @@ public sealed class Event {
     ) : Event()
 
     public data class PointerUp(
-        val button: PointerButton,
+        val button: PointerButtons,
         val locationInWindow: LogicalPoint,
         val state: PointerState,
         val timestamp: Timestamp,
@@ -231,7 +231,7 @@ private fun ncHitTest(s: MemorySegment): Event {
 private fun pointerDown(s: MemorySegment): Event {
     val nativeEvent = NativeEvent.pointer_down(s)
     return Event.PointerDown(
-        button = PointerButton.fromNative(NativePointerButtonEvent.button(nativeEvent)),
+        button = PointerButtons(NativePointerButtonEvent.button(nativeEvent)),
         state = PointerState.fromNative(NativePointerButtonEvent.state(nativeEvent)),
         locationInWindow = LogicalPoint.fromNative(NativePointerButtonEvent.location_in_window(nativeEvent)),
         timestamp = Timestamp(NativePointerButtonEvent.timestamp(nativeEvent)),
@@ -266,7 +266,7 @@ private fun pointerUpdated(s: MemorySegment): Event {
 private fun pointerUp(s: MemorySegment): Event {
     val nativeEvent = NativeEvent.pointer_up(s)
     return Event.PointerUp(
-        button = PointerButton.fromNative(NativePointerButtonEvent.button(nativeEvent)),
+        button = PointerButtons(NativePointerButtonEvent.button(nativeEvent)),
         state = PointerState.fromNative(NativePointerButtonEvent.state(nativeEvent)),
         locationInWindow = LogicalPoint.fromNative(NativePointerButtonEvent.location_in_window(nativeEvent)),
         timestamp = Timestamp(NativePointerButtonEvent.timestamp(nativeEvent)),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Pointer.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Pointer.kt
@@ -1,28 +1,40 @@
 package org.jetbrains.desktop.win32
 
 import org.jetbrains.desktop.win32.generated.NativePointerState
-import org.jetbrains.desktop.win32.generated.desktop_win32_h
 import java.lang.foreign.MemorySegment
 
-public data class PointerState(val pressedButtons: PointerButtons) {
+public data class PointerState(
+    val pressedButtons: PointerButtons,
+    val modifiers: PointerModifiers,
+) {
     internal companion object
 }
 
 @JvmInline
-public value class PointerButton internal constructor(internal val value: Int) {
+public value class PointerButtons internal constructor(private val value: Int) {
     public companion object {
-        public val None: PointerButton = PointerButton(0)
-        public val LeftButton: PointerButton = PointerButton(1)
-        public val RightButton: PointerButton = PointerButton(2)
-        public val MiddleButton: PointerButton = PointerButton(4)
-        public val XButton1: PointerButton = PointerButton(8)
-        public val XButton2: PointerButton = PointerButton(16)
+        public val None: PointerButtons = PointerButtons(0)
+        public val LeftButton: PointerButtons = PointerButtons(1)
+        public val RightButton: PointerButtons = PointerButtons(2)
+        public val MiddleButton: PointerButtons = PointerButtons(4)
+        public val XButton1: PointerButtons = PointerButtons(8)
+        public val XButton2: PointerButtons = PointerButtons(16)
+    }
+
+    public fun hasFlag(button: PointerButtons): Boolean {
+        return (this.value and button.value) == button.value
     }
 }
 
 @JvmInline
-public value class PointerButtons internal constructor(private val value: Int) {
-    public fun hasFlag(button: PointerButton): Boolean {
+public value class PointerModifiers internal constructor(private val value: Int) {
+    public companion object {
+        public val None: PointerModifiers = PointerModifiers(0)
+        public val Shift: PointerModifiers = PointerModifiers(4)
+        public val Control: PointerModifiers = PointerModifiers(8)
+    }
+
+    public fun hasFlag(button: PointerModifiers): Boolean {
         return (this.value and button.value) == button.value
     }
 }
@@ -30,15 +42,6 @@ public value class PointerButtons internal constructor(private val value: Int) {
 internal fun PointerState.Companion.fromNative(s: MemorySegment): PointerState {
     return PointerState(
         pressedButtons = PointerButtons(NativePointerState.pressed_buttons(s)),
+        modifiers = PointerModifiers(NativePointerState.modifiers(s)),
     )
-}
-
-internal fun PointerButton.Companion.fromNative(x: Int): PointerButton = when (x) {
-    desktop_win32_h.NativePointerButton_None() -> None
-    desktop_win32_h.NativePointerButton_Left() -> LeftButton
-    desktop_win32_h.NativePointerButton_Right() -> RightButton
-    desktop_win32_h.NativePointerButton_Middle() -> MiddleButton
-    desktop_win32_h.NativePointerButton_XButton1() -> XButton1
-    desktop_win32_h.NativePointerButton_XButton2() -> XButton2
-    else -> error("Unknown pointer button: $x")
 }

--- a/native/desktop-win32/src/win32/events.rs
+++ b/native/desktop-win32/src/win32/events.rs
@@ -3,7 +3,7 @@ use desktop_common::ffi_utils::RustAllocatedStrPtr;
 use super::{
     geometry::{LogicalPoint, PhysicalPoint, PhysicalSize},
     keyboard::{PhysicalKeyStatus, VirtualKey},
-    pointer::{PointerButton, PointerState},
+    pointer::{PointerButtons, PointerState},
     window_api::WindowId,
 };
 
@@ -96,7 +96,7 @@ impl From<NCHitTestEvent> for Event {
 #[repr(C)]
 #[derive(Debug)]
 pub struct PointerButtonEvent {
-    pub button: PointerButton,
+    pub button: PointerButtons,
     pub location_in_window: LogicalPoint,
     pub state: PointerState,
     pub timestamp: Timestamp,

--- a/native/desktop-win32/src/win32/pointer.rs
+++ b/native/desktop-win32/src/win32/pointer.rs
@@ -1,133 +1,163 @@
-use windows::{
-    UI::Input::{PointerPoint, PointerUpdateKind},
-    Win32::Foundation::WPARAM,
+use windows::Win32::{
+    Foundation::WPARAM,
+    Graphics::Gdi::MapWindowPoints,
+    UI::{
+        HiDpi::GetDpiForWindow,
+        Input::Pointer::{
+            GetPointerInfo, GetPointerPenInfo, GetPointerTouchInfo, GetPointerType, POINTER_FLAG_FIFTHBUTTON, POINTER_FLAG_FIRSTBUTTON,
+            POINTER_FLAG_FOURTHBUTTON, POINTER_FLAG_SECONDBUTTON, POINTER_FLAG_THIRDBUTTON, POINTER_INFO, POINTER_PEN_INFO,
+            POINTER_TOUCH_INFO,
+        },
+        WindowsAndMessaging::{
+            POINTER_INPUT_TYPE, POINTER_MESSAGE_FLAG_FIFTHBUTTON, POINTER_MESSAGE_FLAG_FIRSTBUTTON, POINTER_MESSAGE_FLAG_FOURTHBUTTON,
+            POINTER_MESSAGE_FLAG_SECONDBUTTON, POINTER_MESSAGE_FLAG_THIRDBUTTON, PT_PEN, PT_TOUCH, USER_DEFAULT_SCREEN_DPI,
+        },
+    },
 };
 
 use super::{
-    events::{PointerButtonEvent, Timestamp},
+    events::Timestamp,
     geometry::LogicalPoint,
-    utils::LOWORD,
+    utils::{HIWORD, LOWORD},
 };
 
-#[allow(clippy::cast_possible_truncation)]
-#[allow(clippy::double_parens)]
-#[inline]
-pub(crate) fn get_pointer_point(wparam: WPARAM) -> Option<PointerPoint> {
-    let pointer_id = u32::from(LOWORD!(wparam.0));
-    PointerPoint::GetCurrentPoint(pointer_id)
-        .inspect_err(|err| log::error!("failed to get PointerPoint for pointer ID {pointer_id}: {err}"))
-        .ok()
-}
-
-#[inline]
-pub(crate) fn get_pointer_location_in_window(pointer_point: &PointerPoint) -> Option<LogicalPoint> {
-    let contact_rect = pointer_point
-        .Properties()
-        .and_then(|prop| prop.ContactRect())
-        .inspect_err(|err| log::error!("failed to get PointerPoint.Properties.ContactRect property: {err}"))
-        .ok()?;
-    Some(LogicalPoint::new(contact_rect.X, contact_rect.Y))
-}
-
-#[inline]
-pub(crate) fn get_pointer_state(pointer_point: &PointerPoint) -> Option<PointerState> {
-    PointerState::try_from(pointer_point)
-        .inspect_err(|err| log::error!("failed to get PointerState: {err}"))
-        .ok()
-}
-
-#[inline]
-pub(crate) fn get_pointer_event_timestamp(pointer_point: &PointerPoint) -> Option<Timestamp> {
-    let timestamp = pointer_point
-        .Timestamp()
-        .inspect_err(|err| log::error!("failed to get PointerPoint.Timestamp property: {err}"))
-        .ok()?;
-    Some(Timestamp(timestamp))
+pub(crate) enum PointerInfo {
+    Touch(POINTER_TOUCH_INFO),
+    Pen(POINTER_PEN_INFO),
+    Common(POINTER_INFO),
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct PointerState {
     pressed_buttons: PointerButtons,
-}
-
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum PointerButton {
-    None = 0,
-    Left = 1 << 0,
-    Right = 1 << 1,
-    Middle = 1 << 2,
-    XButton1 = 1 << 3,
-    XButton2 = 1 << 4,
+    modifiers: PointerModifiers,
 }
 
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy)]
 pub struct PointerButtons(u32);
 
-impl TryFrom<&PointerPoint> for PointerState {
-    type Error = windows::core::Error;
+/// cbindgen:ignore
+const POINTER_BUTTON_LEFT: u32 = 1 << 0;
+/// cbindgen:ignore
+const POINTER_BUTTON_RIGHT: u32 = 1 << 1;
+/// cbindgen:ignore
+const POINTER_BUTTON_MIDDLE: u32 = 1 << 2;
+/// cbindgen:ignore
+const POINTER_BUTTON_XBUTTON1: u32 = 1 << 3;
+/// cbindgen:ignore
+const POINTER_BUTTON_XBUTTON2: u32 = 1 << 4;
 
-    fn try_from(value: &PointerPoint) -> Result<Self, Self::Error> {
-        Ok(Self {
-            pressed_buttons: PointerButtons::try_from(value)?,
-        })
-    }
-}
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy)]
+pub struct PointerModifiers(u32);
 
-impl TryFrom<&PointerPoint> for PointerButtons {
-    type Error = windows::core::Error;
+impl PointerInfo {
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::double_parens)]
+    pub(crate) fn try_from_message(wparam: WPARAM) -> windows::core::Result<Self> {
+        let pointer_id = u32::from(LOWORD!(wparam.0));
 
-    fn try_from(value: &PointerPoint) -> Result<Self, Self::Error> {
-        let properties = value.Properties()?;
-        let mut buttons = PointerButton::None as u32;
-        if properties.IsLeftButtonPressed()? {
-            buttons |= PointerButton::Left as u32;
-        }
-        if properties.IsRightButtonPressed()? {
-            buttons |= PointerButton::Right as u32;
-        }
-        if properties.IsMiddleButtonPressed()? {
-            buttons |= PointerButton::Middle as u32;
-        }
-        if properties.IsXButton1Pressed()? {
-            buttons |= PointerButton::XButton1 as u32;
-        }
-        if properties.IsXButton2Pressed()? {
-            buttons |= PointerButton::XButton2 as u32;
-        }
-        Ok(Self(buttons))
-    }
-}
-
-impl TryFrom<&PointerPoint> for PointerButton {
-    type Error = windows::core::Error;
-
-    fn try_from(value: &PointerPoint) -> Result<Self, Self::Error> {
-        let properties = value.Properties()?;
-        let button = match properties.PointerUpdateKind()? {
-            PointerUpdateKind::LeftButtonPressed | PointerUpdateKind::LeftButtonReleased => Self::Left,
-            PointerUpdateKind::RightButtonPressed | PointerUpdateKind::RightButtonReleased => Self::Right,
-            PointerUpdateKind::MiddleButtonPressed | PointerUpdateKind::MiddleButtonReleased => Self::Middle,
-            PointerUpdateKind::XButton1Pressed | PointerUpdateKind::XButton1Released => Self::XButton1,
-            PointerUpdateKind::XButton2Pressed | PointerUpdateKind::XButton2Released => Self::XButton2,
-            _ => Self::None,
+        let pointer_type = unsafe {
+            let mut pointer_type = POINTER_INPUT_TYPE::default();
+            GetPointerType(pointer_id, &raw mut pointer_type)
+                .inspect_err(|err| log::error!("failed to get pointer type for {pointer_id}: {err}"))
+                .map(|()| pointer_type)?
         };
-        Ok(button)
+
+        match pointer_type {
+            PT_TOUCH => unsafe {
+                let mut touch_info = POINTER_TOUCH_INFO::default();
+                GetPointerTouchInfo(pointer_id, &raw mut touch_info)
+                    .inspect_err(|err| log::error!("failed to get pointer touch info for {pointer_id}: {err}"))
+                    .map(|()| Self::Touch(touch_info))
+            },
+            PT_PEN => unsafe {
+                let mut pen_info = POINTER_PEN_INFO::default();
+                GetPointerPenInfo(pointer_id, &raw mut pen_info)
+                    .inspect_err(|err| log::error!("failed to get pointer pen info for {pointer_id}: {err}"))
+                    .map(|()| Self::Pen(pen_info))
+            },
+            _ => unsafe {
+                let mut pointer_info = POINTER_INFO::default();
+                GetPointerInfo(pointer_id, &raw mut pointer_info)
+                    .inspect_err(|err| log::error!("failed to get pointer info for {pointer_id}: {err}"))
+                    .map(|()| Self::Common(pointer_info))
+            },
+        }
+    }
+
+    const fn get_native_pointer_info(&self) -> &POINTER_INFO {
+        match self {
+            Self::Touch(touch_info) => &touch_info.pointerInfo,
+            Self::Pen(pen_info) => &pen_info.pointerInfo,
+            Self::Common(pointer_info) => pointer_info,
+        }
+    }
+
+    pub(crate) fn get_pointer_state(&self) -> PointerState {
+        let native_pointer_info = self.get_native_pointer_info();
+        let pointer_flags = native_pointer_info.pointerFlags;
+        let pressed_buttons = {
+            let mut buttons = 0_u32;
+            if (pointer_flags & POINTER_FLAG_FIRSTBUTTON) == POINTER_FLAG_FIRSTBUTTON {
+                buttons |= POINTER_BUTTON_LEFT;
+            }
+            if (pointer_flags & POINTER_FLAG_SECONDBUTTON) == POINTER_FLAG_SECONDBUTTON {
+                buttons |= POINTER_BUTTON_RIGHT;
+            }
+            if (pointer_flags & POINTER_FLAG_THIRDBUTTON) == POINTER_FLAG_THIRDBUTTON {
+                buttons |= POINTER_BUTTON_MIDDLE;
+            }
+            if (pointer_flags & POINTER_FLAG_FOURTHBUTTON) == POINTER_FLAG_FOURTHBUTTON {
+                buttons |= POINTER_BUTTON_XBUTTON1;
+            }
+            if (pointer_flags & POINTER_FLAG_FIFTHBUTTON) == POINTER_FLAG_FIFTHBUTTON {
+                buttons |= POINTER_BUTTON_XBUTTON2;
+            }
+            PointerButtons(buttons)
+        };
+        PointerState {
+            pressed_buttons,
+            modifiers: unsafe { core::mem::transmute::<u32, PointerModifiers>(native_pointer_info.dwKeyStates) },
+        }
+    }
+
+    pub(crate) fn get_timestamp(&self) -> Timestamp {
+        let native_pointer_info = self.get_native_pointer_info();
+        Timestamp(u64::from(native_pointer_info.dwTime) * 1000)
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    pub(crate) fn get_location_in_window(&self) -> LogicalPoint {
+        let native_pointer_info = self.get_native_pointer_info();
+        let window_dpi = unsafe { GetDpiForWindow(native_pointer_info.hwndTarget) };
+        let mut points = [native_pointer_info.ptPixelLocation];
+        unsafe { MapWindowPoints(None, Some(native_pointer_info.hwndTarget), &mut points) };
+        let x = ((points[0].x * USER_DEFAULT_SCREEN_DPI as i32) as f32) / (window_dpi as f32);
+        let y = ((points[0].y * USER_DEFAULT_SCREEN_DPI as i32) as f32) / (window_dpi as f32);
+        LogicalPoint::new(x, y)
     }
 }
 
-impl TryFrom<&PointerPoint> for PointerButtonEvent {
-    type Error = windows::core::Error;
-
-    fn try_from(value: &PointerPoint) -> Result<Self, Self::Error> {
-        let position = value.Position()?;
-        Ok(Self {
-            button: PointerButton::try_from(value)?,
-            location_in_window: LogicalPoint::new(position.X, position.Y),
-            state: PointerState::try_from(value)?,
-            timestamp: Timestamp(value.Timestamp()?),
-        })
+impl PointerButtons {
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::double_parens)]
+    pub(crate) fn from_message_flags(value: WPARAM) -> Self {
+        let flags = u32::from(HIWORD!(value.0));
+        if (flags & POINTER_MESSAGE_FLAG_FIRSTBUTTON) == POINTER_MESSAGE_FLAG_FIRSTBUTTON {
+            Self(POINTER_BUTTON_LEFT)
+        } else if (flags & POINTER_MESSAGE_FLAG_SECONDBUTTON) == POINTER_MESSAGE_FLAG_SECONDBUTTON {
+            Self(POINTER_BUTTON_RIGHT)
+        } else if (flags & POINTER_MESSAGE_FLAG_THIRDBUTTON) == POINTER_MESSAGE_FLAG_THIRDBUTTON {
+            Self(POINTER_BUTTON_MIDDLE)
+        } else if (flags & POINTER_MESSAGE_FLAG_FOURTHBUTTON) == POINTER_MESSAGE_FLAG_FOURTHBUTTON {
+            Self(POINTER_BUTTON_XBUTTON1)
+        } else if (flags & POINTER_MESSAGE_FLAG_FIFTHBUTTON) == POINTER_MESSAGE_FLAG_FIFTHBUTTON {
+            Self(POINTER_BUTTON_XBUTTON2)
+        } else {
+            Self(0_u32)
+        }
     }
 }

--- a/native/desktop-win32/src/win32/utils.rs
+++ b/native/desktop-win32/src/win32/utils.rs
@@ -28,7 +28,13 @@ macro_rules! GET_Y_LPARAM {
     };
 }
 
-pub(crate) use {GET_X_LPARAM, GET_Y_LPARAM, HIWORD, LOBYTE, LOWORD};
+macro_rules! GET_WHEEL_DELTA_WPARAM {
+    ($arg:ident) => {
+        ((((($arg.0) as usize >> 16) & 0xffff) as i16) as i32)
+    };
+}
+
+pub(crate) use {GET_WHEEL_DELTA_WPARAM, GET_X_LPARAM, GET_Y_LPARAM, HIWORD, LOBYTE, LOWORD};
 
 pub(crate) fn is_windows_11_build_22000_or_higher() -> bool {
     unsafe {


### PR DESCRIPTION
This change greatly improves performance of pointer events, so much that on Adreno GPU the resize lag is not noticeable anymore. This doesn't change the fact that we need a separate rendering thread, but this shows how much time we were spending inside pointer event handlers.