### PR TITLE
chore: upgrade JDK toolchain from 21 to 25

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ env:
 jobs:
   build_all:
     strategy:
+      fail-fast: false
       matrix:
         targets: [
           { os: "macos-15", rust_targets: "aarch64-apple-darwin", package_manager: "brew" },
@@ -27,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         if: "${{ matrix.targets.package_manager == 'apt' }}"
@@ -45,7 +46,7 @@ jobs:
           cache: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 25

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: 25
 
       - name: Setup Gradle

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: 25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Publish with Gradle

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         if: "${{ matrix.targets.package_manager == 'apt' }}"
@@ -56,7 +56,7 @@ jobs:
           cache: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 25

--- a/kotlin-desktop-toolkit/build.gradle.kts
+++ b/kotlin-desktop-toolkit/build.gradle.kts
@@ -77,14 +77,10 @@ dependencies {
     implementation(kotlin("stdlib"))
 }
 
-tasks.compileJava {
-    options.compilerArgs = listOf("--enable-preview")
-}
-
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     withSourcesJar()
 }
@@ -998,7 +994,7 @@ val testWayland = tasks.register<Test>("testWayland") {
 
 fun configureTestTask(test: Test, backends: List<Backend>) {
     test.apply {
-        jvmArgs("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+        jvmArgs("--enable-native-access=ALL-UNNAMED")
         useJUnitPlatform()
         addTestListener(object : TestListener {
             private fun getPrintableTestName(descriptor: TestDescriptor?): String {

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Application.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Application.kt
@@ -328,7 +328,7 @@ public class Application(public val appId: String) {
     public fun clipboardGetAvailableMimeTypes(): List<String> {
         val ffiCsvMimetypes = ffiDownCall { desktop_gtk_h.application_clipboard_get_available_mimetypes() }
         return try {
-            splitCsv(ffiCsvMimetypes.getUtf8String(0))
+            splitCsv(ffiCsvMimetypes.getString(0))
         } finally {
             ffiDownCall { desktop_gtk_h.string_drop(ffiCsvMimetypes) }
         }
@@ -359,7 +359,7 @@ public class Application(public val appId: String) {
     public fun primarySelectionGetAvailableMimeTypes(): List<String> {
         val ffiCsvMimetypes = ffiDownCall { desktop_gtk_h.application_primary_selection_get_available_mimetypes() }
         return try {
-            splitCsv(ffiCsvMimetypes.getUtf8String(0))
+            splitCsv(ffiCsvMimetypes.getString(0))
         } finally {
             ffiDownCall { desktop_gtk_h.string_drop(ffiCsvMimetypes) }
         }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Converters.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Converters.kt
@@ -474,7 +474,7 @@ internal fun ByteArray?.toNative(arena: Arena): MemorySegment {
     } else {
         NativeBorrowedArray_u8.len(nativeDataArray, size.toLong())
 
-        val nativeArray = arena.allocateArray(ValueLayout.JAVA_BYTE, *this)
+        val nativeArray = arena.allocateFrom(ValueLayout.JAVA_BYTE, *this)
         NativeBorrowedArray_u8.ptr(nativeDataArray, nativeArray)
     }
 
@@ -494,7 +494,7 @@ internal fun String?.toNativeUtf8(arena: Arena): MemorySegment {
         }
         NativeBorrowedUtf8.len(native, byteArraySize.toLong())
 
-        val nativeArray = arena.allocateArray(ValueLayout.JAVA_BYTE, *byteArray)
+        val nativeArray = arena.allocateFrom(ValueLayout.JAVA_BYTE, *byteArray)
         NativeBorrowedUtf8.ptr(native, nativeArray)
     }
 

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Logger.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Logger.kt
@@ -188,7 +188,7 @@ internal fun initLogger(logFile: Path, consoleLogLevel: LogLevel, fileLogLevel: 
         Arena.ofConfined().use { arena ->
             val configuration = NativeLoggerConfiguration.allocate(arena)
             val logFileStr = logFile.toAbsolutePath().toString()
-            NativeLoggerConfiguration.file_path(configuration, arena.allocateUtf8String(logFileStr))
+            NativeLoggerConfiguration.file_path(configuration, arena.allocateFrom(logFileStr))
             NativeLoggerConfiguration.console_level(configuration, consoleLogLevel.toNative())
             NativeLoggerConfiguration.file_level(configuration, fileLogLevel.toNative())
             desktop_gtk_h.logger_init(configuration)
@@ -207,7 +207,7 @@ private fun checkExceptions(): List<String> {
         if (count != 0L) {
             (0 until count).map { i ->
                 val cStrPtr = items.getAtIndex(NativeExceptionsArray.`items$layout`(), i)
-                cStrPtr.getUtf8String(0)
+                cStrPtr.getString(0)
             }.toList()
         } else {
             emptyList()

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Screen.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/gtk/Screen.kt
@@ -22,7 +22,7 @@ public data class Screen internal constructor(
                 name = if (nativeName == MemorySegment.NULL) {
                     null
                 } else {
-                    nativeName.getUtf8String(0)
+                    nativeName.getString(0)
                 },
                 origin = LogicalPoint.fromNative(NativeScreenInfo.origin(s)),
                 size = LogicalSize.fromNative(NativeScreenInfo.size(s)),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
@@ -501,7 +501,7 @@ internal fun ByteArray?.toNative(arena: Arena): MemorySegment {
     } else {
         NativeBorrowedArray_u8.len(nativeDataArray, size.toLong())
 
-        val nativeArray = arena.allocateArray(ValueLayout.JAVA_BYTE, *this)
+        val nativeArray = arena.allocateFrom(ValueLayout.JAVA_BYTE, *this)
         NativeBorrowedArray_u8.ptr(nativeDataArray, nativeArray)
     }
 
@@ -521,7 +521,7 @@ internal fun String?.toNativeUtf8(arena: Arena): MemorySegment {
         }
         NativeBorrowedUtf8.len(native, byteArraySize.toLong())
 
-        val nativeArray = arena.allocateArray(ValueLayout.JAVA_BYTE, *byteArray)
+        val nativeArray = arena.allocateFrom(ValueLayout.JAVA_BYTE, *byteArray)
         NativeBorrowedUtf8.ptr(native, nativeArray)
     }
 

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Logger.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Logger.kt
@@ -188,7 +188,7 @@ internal fun initLogger(logFile: Path, consoleLogLevel: LogLevel, fileLogLevel: 
         Arena.ofConfined().use { arena ->
             val configuration = NativeLoggerConfiguration.allocate(arena)
             val logFileStr = logFile.toAbsolutePath().toString()
-            NativeLoggerConfiguration.file_path(configuration, arena.allocateUtf8String(logFileStr))
+            NativeLoggerConfiguration.file_path(configuration, arena.allocateFrom(logFileStr))
             NativeLoggerConfiguration.console_level(configuration, consoleLogLevel.toNative())
             NativeLoggerConfiguration.file_level(configuration, fileLogLevel.toNative())
             desktop_linux_h.logger_init(configuration)
@@ -207,7 +207,7 @@ private fun checkExceptions(): List<String> {
         if (count != 0L) {
             (0 until count).map { i ->
                 val cStrPtr = items.getAtIndex(NativeExceptionsArray.`items$layout`(), i)
-                cStrPtr.getUtf8String(0)
+                cStrPtr.getString(0)
             }.toList()
         } else {
             emptyList()

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Application.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Application.kt
@@ -61,7 +61,7 @@ public object Application {
         get() {
             val name = ffiDownCall { desktop_macos_h.application_get_name() }
             return try {
-                name.getUtf8String(0)
+                name.getString(0)
             } finally {
                 ffiDownCall { desktop_macos_h.string_drop(name) }
             }
@@ -130,7 +130,7 @@ public object Application {
     public fun setDockIconBadge(label: String) {
         ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.application_set_dock_icon_badge(arena.allocateUtf8String(label))
+                desktop_macos_h.application_set_dock_icon_badge(arena.allocateFrom(label))
             }
         }
     }
@@ -173,7 +173,7 @@ public object Application {
     public fun openURL(url: String) {
         ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.application_open_url(arena.allocateUtf8String(url))
+                desktop_macos_h.application_open_url(arena.allocateFrom(url))
             }
         }
     }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/ApplicationMenu.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/ApplicationMenu.kt
@@ -192,7 +192,7 @@ public object AppMenuManager {
 
 private fun Keystroke.toNative(arena: Arena): MemorySegment = let { keystroke ->
     val result = NativeAppMenuKeystroke.allocate(arena)
-    NativeAppMenuKeystroke.key(result, arena.allocateUtf8String(keystroke.key))
+    NativeAppMenuKeystroke.key(result, arena.allocateFrom(keystroke.key))
     NativeAppMenuKeystroke.modifiers(result, keystroke.modifiers.value)
     result
 }
@@ -208,7 +208,7 @@ private fun AppMenuItem.toNative(nativeItem: MemorySegment, arena: Arena): Unit 
             val actionItemBody = NativeAppMenuItem_NativeActionItem_Body.allocate(arena)
             NativeAppMenuItem_NativeActionItem_Body.enabled(actionItemBody, menuItem.isEnabled)
             NativeAppMenuItem_NativeActionItem_Body.state(actionItemBody, menuItem.state.toNative())
-            NativeAppMenuItem_NativeActionItem_Body.title(actionItemBody, arena.allocateUtf8String(menuItem.title))
+            NativeAppMenuItem_NativeActionItem_Body.title(actionItemBody, arena.allocateFrom(menuItem.title))
             NativeAppMenuItem_NativeActionItem_Body.special_tag(actionItemBody, menuItem.specialTag.toNative())
             NativeAppMenuItem_NativeActionItem_Body.keystroke(actionItemBody, menuItem.keystroke?.toNative(arena) ?: MemorySegment.NULL)
             NativeAppMenuItem_NativeActionItem_Body.item_id(actionItemBody, itemId)
@@ -229,7 +229,7 @@ private fun AppMenuItem.toNative(nativeItem: MemorySegment, arena: Arena): Unit 
             }
 
             val subMenuItemBody = NativeAppMenuItem_NativeSubMenuItem_Body.allocate(arena)
-            NativeAppMenuItem_NativeSubMenuItem_Body.title(subMenuItemBody, arena.allocateUtf8String(menuItem.title))
+            NativeAppMenuItem_NativeSubMenuItem_Body.title(subMenuItemBody, arena.allocateFrom(menuItem.title))
             NativeAppMenuItem_NativeSubMenuItem_Body.special_tag(subMenuItemBody, menuItem.specialTag.toNative())
             NativeAppMenuItem_NativeSubMenuItem_Body.items_count(subMenuItemBody, menuItem.items.size.toLong())
             NativeAppMenuItem_NativeSubMenuItem_Body.items(subMenuItemBody, itemsArray)

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Converters.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Converters.kt
@@ -84,15 +84,15 @@ internal fun listOfStringsFromNative(segment: MemorySegment): List<String> {
 
     return (0 until len).map { i ->
         val strPtr = ptr.getAtIndex(NativeAutoDropArray_RustAllocatedStrPtr.`ptr$layout`(), i)
-        strPtr.getUtf8String(0)
+        strPtr.getString(0)
     }.toList()
 }
 
 internal fun listOfStringsToNative(arena: Arena, list: List<String>): MemorySegment {
     val itemsCount = list.count().toLong()
-    val itemsArray = arena.allocateArray(NativeBorrowedStrPtr, itemsCount)
+    val itemsArray = arena.allocate(NativeBorrowedStrPtr, itemsCount)
     list.forEachIndexed { index, item ->
-        val strPtr = arena.allocateUtf8String(item)
+        val strPtr = arena.allocateFrom(item)
         itemsArray.setAtIndex(NativeBorrowedStrPtr, index.toLong(), strPtr)
     }
     val result = NativeBorrowedArray_BorrowedStrPtr.allocate(arena)
@@ -103,7 +103,7 @@ internal fun listOfStringsToNative(arena: Arena, list: List<String>): MemorySegm
 
 internal fun ByteArray.toNative(arena: Arena): MemorySegment = let { bytes ->
     val result = NativeBorrowedArray_u8.allocate(arena)
-    NativeBorrowedArray_u8.ptr(result, arena.allocateArray(JAVA_BYTE, *bytes))
+    NativeBorrowedArray_u8.ptr(result, arena.allocateFrom(JAVA_BYTE, *bytes))
     NativeBorrowedArray_u8.len(result, bytes.count().toLong())
     result
 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/DragAndDrop.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/DragAndDrop.kt
@@ -61,7 +61,7 @@ public data class DragInfo(
             val locationInWindow = LogicalPoint.fromNative(NativeDragTargetInfo.location_in_window(segment))
             val allowedOperations = DragOperationsSet(NativeDragTargetInfo.allowed_operations(segment))
             val sequenceNumber = NativeDragTargetInfo.sequence_number(segment)
-            val pasteboardName = NativeDragTargetInfo.pasteboard_name(segment).getUtf8String(0)
+            val pasteboardName = NativeDragTargetInfo.pasteboard_name(segment).getString(0)
             return DragInfo(
                 destinationWindowId,
                 locationInWindow,

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Event.kt
@@ -87,7 +87,7 @@ public sealed class Event {
             var result: MemorySegment = MemorySegment.NULL
             return try {
                 result = ffiDownCall { desktop_macos_h.events_characters_by_applying_modifiers(modifiers.value) }
-                Characters(result.getUtf8String(0))
+                Characters(result.getString(0))
             } finally {
                 if (result != MemorySegment.NULL) {
                     ffiDownCall { desktop_macos_h.string_drop(result) }
@@ -311,10 +311,10 @@ internal fun Event.Companion.fromNative(s: MemorySegment): Event {
             Event.KeyDown(
                 windowId = NativeKeyDownEvent.window_id(nativeEvent),
                 keyCode = KeyCode.fromNative(NativeKeyDownEvent.code(nativeEvent)),
-                characters = Characters(NativeKeyDownEvent.characters(nativeEvent).getUtf8String(0)),
+                characters = Characters(NativeKeyDownEvent.characters(nativeEvent).getString(0)),
                 key = Event.charactersByApplyingModifiersForCurrentEvent(KeyModifiersSet.create()),
                 keyWithModifiers = Event.charactersByApplyingModifiersForCurrentEvent(modifiers),
-                charactersIgnoringModifiers = Characters(NativeKeyDownEvent.characters_ignoring_modifiers(nativeEvent).getUtf8String(0)),
+                charactersIgnoringModifiers = Characters(NativeKeyDownEvent.characters_ignoring_modifiers(nativeEvent).getString(0)),
                 modifiers = modifiers,
                 isRepeat = NativeKeyDownEvent.is_repeat(nativeEvent),
                 mightHaveKeyEquivalent = NativeKeyDownEvent.might_have_key_equivalent(nativeEvent),
@@ -326,10 +326,10 @@ internal fun Event.Companion.fromNative(s: MemorySegment): Event {
             val modifiers = KeyModifiersSet(NativeKeyUpEvent.modifiers(nativeEvent))
             Event.KeyUp(
                 windowId = NativeKeyUpEvent.window_id(nativeEvent),
-                characters = Characters(NativeKeyUpEvent.characters(nativeEvent).getUtf8String(0)),
+                characters = Characters(NativeKeyUpEvent.characters(nativeEvent).getString(0)),
                 key = Event.charactersByApplyingModifiersForCurrentEvent(KeyModifiersSet.create()),
                 keyWithModifiers = Event.charactersByApplyingModifiersForCurrentEvent(modifiers),
-                charactersIgnoringModifiers = Characters(NativeKeyUpEvent.characters_ignoring_modifiers(nativeEvent).getUtf8String(0)),
+                charactersIgnoringModifiers = Characters(NativeKeyUpEvent.characters_ignoring_modifiers(nativeEvent).getString(0)),
                 modifiers = modifiers,
                 keyCode = KeyCode.fromNative(NativeKeyUpEvent.code(nativeEvent)),
                 timestamp = Timestamp(NativeKeyUpEvent.timestamp(nativeEvent)),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/FileDialog.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/FileDialog.kt
@@ -36,7 +36,7 @@ public object FileDialog {
                 val result = desktop_macos_h.save_file_dialog_run_modal(nativeCommonDialogParams)
                 if (result != MemorySegment.NULL) {
                     try {
-                        result.getUtf8String(0)
+                        result.getString(0)
                     } finally {
                         ffiDownCall { desktop_macos_h.string_drop(result) }
                     }
@@ -71,17 +71,17 @@ public object FileDialog {
 
     internal fun CommonDialogParams.toNative(arena: Arena): MemorySegment {
         val result = NativeCommonFileDialogParams.allocate(arena)
-        NativeCommonFileDialogParams.title(result, title?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
-        NativeCommonFileDialogParams.prompt(result, prompt?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
-        NativeCommonFileDialogParams.message(result, message?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
-        NativeCommonFileDialogParams.name_field_label(result, nameFieldLabel?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
+        NativeCommonFileDialogParams.title(result, title?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
+        NativeCommonFileDialogParams.prompt(result, prompt?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
+        NativeCommonFileDialogParams.message(result, message?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
+        NativeCommonFileDialogParams.name_field_label(result, nameFieldLabel?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
         NativeCommonFileDialogParams.name_field_string_value(
             result,
             nameFieldStringValue?.let {
-                arena.allocateUtf8String(it)
+                arena.allocateFrom(it)
             } ?: MemorySegment.NULL,
         )
-        NativeCommonFileDialogParams.directory_url(result, directoryUrl?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
+        NativeCommonFileDialogParams.directory_url(result, directoryUrl?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
         NativeCommonFileDialogParams.can_create_directories(result, canCreateDirectories)
         NativeCommonFileDialogParams.can_select_hidden_extension(result, canSelectHiddenExtensions)
         NativeCommonFileDialogParams.shows_hidden_files(result, showsHiddenFiles)

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Image.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Image.kt
@@ -14,7 +14,7 @@ public class Image(private val data: ByteArray) {
      * The returned MemorySegment is allocated in the provided arena.
      */
     internal fun toNative(arena: Arena): MemorySegment {
-        val dataSegment = arena.allocateArray(ValueLayout.JAVA_BYTE, *data)
+        val dataSegment = arena.allocateFrom(ValueLayout.JAVA_BYTE, *data)
         val imageStruct = NativeImage.allocate(arena)
         NativeImage.data(imageStruct, dataSegment)
         NativeImage.data_length(imageStruct, dataSegment.byteSize())

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Logger.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Logger.kt
@@ -188,7 +188,7 @@ internal fun initLogger(logFile: Path, consoleLogLevel: LogLevel, fileLogLevel: 
         Arena.ofConfined().use { arena ->
             val configuration = NativeLoggerConfiguration.allocate(arena)
             val logFileStr = logFile.toAbsolutePath().toString()
-            NativeLoggerConfiguration.file_path(configuration, arena.allocateUtf8String(logFileStr))
+            NativeLoggerConfiguration.file_path(configuration, arena.allocateFrom(logFileStr))
             NativeLoggerConfiguration.console_level(configuration, consoleLogLevel.toNative())
             NativeLoggerConfiguration.file_level(configuration, fileLogLevel.toNative())
             desktop_macos_h.logger_init(configuration)
@@ -207,7 +207,7 @@ private fun checkExceptions(): List<String> {
         if (count != 0L) {
             (0 until count).map { i ->
                 val cStrPtr = items.getAtIndex(NativeExceptionsArray.`items$layout`(), i)
-                cStrPtr.getUtf8String(0)
+                cStrPtr.getString(0)
             }.toList()
         } else {
             emptyList()

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/NotificationCenter.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/NotificationCenter.kt
@@ -206,7 +206,7 @@ public object NotificationCenter : AutoCloseable {
         ffiDownCall {
             Arena.ofConfined().use { arena ->
                 // Allocate array of NativeNotificationCategory structs
-                val categoriesArray = arena.allocateArray(NativeNotificationCategory.layout(), categories.size.toLong())
+                val categoriesArray = arena.allocate(NativeNotificationCategory.layout(), categories.size.toLong())
 
                 categories.forEachIndexed { categoryIndex, category ->
                     val categorySegment = categoriesArray.asSlice(
@@ -215,19 +215,19 @@ public object NotificationCenter : AutoCloseable {
                     )
 
                     // Allocate category ID
-                    val categoryIdPtr = arena.allocateUtf8String(category.categoryId.value)
+                    val categoryIdPtr = arena.allocateFrom(category.categoryId.value)
                     NativeNotificationCategory.category_id(categorySegment, categoryIdPtr)
 
                     // Allocate array of NativeNotificationAction structs for this category
-                    val actionsArray = arena.allocateArray(NativeNotificationAction.layout(), category.actions.size.toLong())
+                    val actionsArray = arena.allocate(NativeNotificationAction.layout(), category.actions.size.toLong())
                     category.actions.forEachIndexed { actionIndex, action ->
                         val actionSegment = actionsArray.asSlice(
                             actionIndex * NativeNotificationAction.layout().byteSize(),
                             NativeNotificationAction.layout(),
                         )
 
-                        val actionIdPtr = arena.allocateUtf8String(action.actionId.value)
-                        val actionTitlePtr = arena.allocateUtf8String(action.title)
+                        val actionIdPtr = arena.allocateFrom(action.actionId.value)
+                        val actionTitlePtr = arena.allocateFrom(action.title)
 
                         NativeNotificationAction.identifier(actionSegment, actionIdPtr)
                         NativeNotificationAction.title(actionSegment, actionTitlePtr)
@@ -292,11 +292,11 @@ public object NotificationCenter : AutoCloseable {
         try {
             ffiDownCall {
                 Arena.ofConfined().use { arena ->
-                    val identifierPtr = arena.allocateUtf8String(notificationId.value)
-                    val titlePtr = arena.allocateUtf8String(title)
-                    val bodyPtr = arena.allocateUtf8String(body)
-                    val soundNamePtr = arena.allocateUtf8String(sound.getSoundName())
-                    val categoryIdPtr = arena.allocateUtf8String(categoryId.value)
+                    val identifierPtr = arena.allocateFrom(notificationId.value)
+                    val titlePtr = arena.allocateFrom(title)
+                    val bodyPtr = arena.allocateFrom(body)
+                    val soundNamePtr = arena.allocateFrom(sound.getSoundName())
+                    val categoryIdPtr = arena.allocateFrom(categoryId.value)
 
                     // Allocate and populate the NotificationRequest struct
                     val requestSegment = arena.allocate(NativeNotificationRequest.layout())
@@ -324,7 +324,7 @@ public object NotificationCenter : AutoCloseable {
     public fun removeNotification(notificationId: NotificationId) {
         ffiDownCall {
             Arena.ofConfined().use { arena ->
-                val identifierPtr = arena.allocateUtf8String(notificationId.value)
+                val identifierPtr = arena.allocateFrom(notificationId.value)
                 desktop_macos_h.notification_remove(identifierPtr)
             }
         }
@@ -403,11 +403,11 @@ public object NotificationCenter : AutoCloseable {
     // Called from native when notification delivery completes
     private fun onNotificationDeliveryComplete(notificationIdentifier: MemorySegment, errorMessage: MemorySegment) {
         ffiUpCall {
-            val notificationId = NotificationId(notificationIdentifier.getUtf8String(0))
+            val notificationId = NotificationId(notificationIdentifier.getString(0))
             val error = if (errorMessage.address() == 0L) {
                 null
             } else {
-                errorMessage.getUtf8String(0)
+                errorMessage.getString(0)
             }
             showNotificationCallbacks.remove(notificationId)?.invoke(error)
                 ?: Logger.error { "onNotificationDeliveryComplete: no callback registered for notification $notificationId" }
@@ -417,8 +417,8 @@ public object NotificationCenter : AutoCloseable {
     // Called from native when user clicks an action button
     private fun onActionResponse(actionIdPtr: MemorySegment, notificationIdPtr: MemorySegment) {
         ffiUpCall {
-            val actionId = ActionId(actionIdPtr.getUtf8String(0))
-            val notificationId = NotificationId(notificationIdPtr.getUtf8String(0))
+            val actionId = ActionId(actionIdPtr.getString(0))
+            val notificationId = NotificationId(notificationIdPtr.getString(0))
             actionResponseCallback.invoke(notificationId, actionId)
         }
     }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Pasteboard.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Pasteboard.kt
@@ -124,7 +124,7 @@ public object Pasteboard {
         return Arena.ofConfined().use { arena ->
             ffiDownCall {
                 desktop_macos_h.pasteboard_clear(
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                 )
             }
         }
@@ -152,7 +152,7 @@ public object Pasteboard {
         return Arena.ofConfined().use { arena ->
             ffiDownCall {
                 desktop_macos_h.pasteboard_write_objects(
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                     items.toNative(arena),
                 )
             }
@@ -173,8 +173,8 @@ public object Pasteboard {
             val nativeResult = ffiDownCall {
                 desktop_macos_h.pasteboard_read_items_of_type(
                     arena,
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
-                    arena.allocateUtf8String(type),
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
+                    arena.allocateFrom(type),
                 )
             }
             val items = NativePasteboardContentResult.items(nativeResult)
@@ -217,7 +217,7 @@ public object Pasteboard {
         return Arena.ofConfined().use { arena ->
             ffiDownCall {
                 desktop_macos_h.pasteboard_read_change_count(
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                 )
             }
         }
@@ -233,7 +233,7 @@ public object Pasteboard {
         return Arena.ofConfined().use { arena ->
             ffiDownCall {
                 desktop_macos_h.pasteboard_read_items_count(
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                 )
             }
         }
@@ -253,7 +253,7 @@ public object Pasteboard {
             val nativeResult = ffiDownCall {
                 desktop_macos_h.pasteboard_read_item_types(
                     arena,
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                     itemIndex.toLong(),
                 )
             }
@@ -284,9 +284,9 @@ public object Pasteboard {
             val nativeResult = ffiDownCall {
                 desktop_macos_h.pasteboard_read_item_data(
                     arena,
-                    pasteboard.toNameOrNull()?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL,
+                    pasteboard.toNameOrNull()?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL,
                     itemIndex.toLong(),
-                    arena.allocateUtf8String(type),
+                    arena.allocateFrom(type),
                 )
             }
             val found = NativePasteboardItemDataResult.found(nativeResult)
@@ -330,7 +330,7 @@ public value class PasteboardType internal constructor(internal val name: String
 // IMPL:
 
 internal fun Pasteboard.Element.toNative(natiiveElement: MemorySegment, arena: Arena) = let { element ->
-    NativeCombinedItemElement.uniform_type_identifier(natiiveElement, arena.allocateUtf8String(element.type))
+    NativeCombinedItemElement.uniform_type_identifier(natiiveElement, arena.allocateFrom(element.type))
     NativeCombinedItemElement.content(natiiveElement, element.content.toNative(arena))
 }
 

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Screen.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Screen.kt
@@ -78,8 +78,8 @@ public data class Screen(
             return Screen(
                 screenId = NativeScreenInfo.screen_id(s),
                 isPrimary = NativeScreenInfo.is_primary(s),
-                name = NativeScreenInfo.name(s).getUtf8String(0),
-                uuid = NativeScreenInfo.uuid(s).getUtf8String(0),
+                name = NativeScreenInfo.name(s).getString(0),
+                uuid = NativeScreenInfo.uuid(s).getString(0),
                 origin = LogicalPoint.fromNative(NativeScreenInfo.origin(s)),
                 size = LogicalSize.fromNative(NativeScreenInfo.size(s)),
                 scale = NativeScreenInfo.scale(s),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Sound.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Sound.kt
@@ -25,7 +25,7 @@ public object Sound {
     public fun playNamed(soundName: String): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                val soundNamePtr = arena.allocateUtf8String(soundName)
+                val soundNamePtr = arena.allocateFrom(soundName)
                 desktop_macos_h.sound_play_named(soundNamePtr)
             }
         }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/TextInputClient.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/TextInputClient.kt
@@ -229,7 +229,7 @@ internal data class TextInputClientHolder(var textInputClient: TextInputClient =
     // called from native code
     private fun insertTextCallback(s: MemorySegment) {
         ffiUpCall {
-            val text = NativeInsertTextArgs.text(s).getUtf8String(0)
+            val text = NativeInsertTextArgs.text(s).getString(0)
             val replacementRange = TextRange.fromNative(NativeInsertTextArgs.replacement_range(s)).nullIfNotFound()
             textInputClient.insertText(text = text, replacementRange = replacementRange)
         }
@@ -238,7 +238,7 @@ internal data class TextInputClientHolder(var textInputClient: TextInputClient =
     // called from native code
     private fun setMarkedTextCallback(args: MemorySegment) {
         ffiUpCall {
-            val text = NativeSetMarkedTextArgs.text(args).getUtf8String(0)
+            val text = NativeSetMarkedTextArgs.text(args).getString(0)
             val selectedRange = TextRange.fromNative(NativeSetMarkedTextArgs.selected_range(args)).nullIfNotFound()
             val replacementRange = TextRange.fromNative(NativeSetMarkedTextArgs.replacement_range(args)).nullIfNotFound()
             textInputClient.setMarkedText(text, selectedRange = selectedRange, replacementRange = replacementRange)
@@ -266,7 +266,7 @@ internal data class TextInputClientHolder(var textInputClient: TextInputClient =
 
                 (stringAndRange.actualRange ?: TextRange.notFound).toNative(NativeAttributedStringForRangeResult.actual_range(result))
                 if (stringAndRange.text != null) {
-                    NativeAttributedStringForRangeResult.string(result, localArena.allocateUtf8String(stringAndRange.text))
+                    NativeAttributedStringForRangeResult.string(result, localArena.allocateFrom(stringAndRange.text))
                 } else {
                     NativeAttributedStringForRangeResult.string(result, MemorySegment.NULL)
                 }
@@ -308,7 +308,7 @@ internal data class TextInputClientHolder(var textInputClient: TextInputClient =
     // called from native code
     private fun doCommandCallback(command: MemorySegment): Boolean {
         return ffiUpCall(defaultResult = false) {
-            textInputClient.doCommand(command.getUtf8String(0))
+            textInputClient.doCommand(command.getString(0))
         }
     }
 

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/TextInputSource.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/TextInputSource.kt
@@ -90,7 +90,7 @@ public object TextInputSource {
         }
         if (layout == MemorySegment.NULL) return null
         return try {
-            layout.getUtf8String(0)
+            layout.getString(0)
         } finally {
             ffiDownCall { desktop_macos_h.string_drop(layout) }
         }
@@ -141,7 +141,7 @@ public object TextInputSource {
     public fun select(sourceId: String): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_select(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_select(arena.allocateFrom(sourceId))
             }
         }
     }
@@ -164,12 +164,12 @@ public object TextInputSource {
     public fun type(sourceId: String): String? {
         val typePtr = ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_type(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_type(arena.allocateFrom(sourceId))
             }
         }
         if (typePtr == MemorySegment.NULL) return null
         return try {
-            typePtr.getUtf8String(0)
+            typePtr.getString(0)
         } finally {
             ffiDownCall { desktop_macos_h.string_drop(typePtr) }
         }
@@ -189,12 +189,12 @@ public object TextInputSource {
     public fun getParent(sourceId: String): String? {
         val parentPtr = ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_get_parent(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_get_parent(arena.allocateFrom(sourceId))
             }
         }
         if (parentPtr == MemorySegment.NULL) return null
         return try {
-            parentPtr.getUtf8String(0)
+            parentPtr.getString(0)
         } finally {
             ffiDownCall { desktop_macos_h.string_drop(parentPtr) }
         }
@@ -208,7 +208,7 @@ public object TextInputSource {
     public fun isAsciiCapable(sourceId: String): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_is_ascii_capable(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_is_ascii_capable(arena.allocateFrom(sourceId))
             }
         }
     }
@@ -226,7 +226,7 @@ public object TextInputSource {
     public fun isSelectCapable(sourceId: String): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_is_select_capable(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_is_select_capable(arena.allocateFrom(sourceId))
             }
         }
     }
@@ -245,7 +245,7 @@ public object TextInputSource {
     public fun isEnableCapable(sourceId: String): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_is_enable_capable(arena.allocateUtf8String(sourceId))
+                desktop_macos_h.text_input_source_is_enable_capable(arena.allocateFrom(sourceId))
             }
         }
     }
@@ -270,7 +270,7 @@ public object TextInputSource {
     public fun setEnabled(sourceId: String, enabled: Boolean): Boolean {
         return ffiDownCall {
             Arena.ofConfined().use { arena ->
-                desktop_macos_h.text_input_source_set_enable(arena.allocateUtf8String(sourceId), enabled)
+                desktop_macos_h.text_input_source_set_enable(arena.allocateFrom(sourceId), enabled)
             }
         }
     }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/UrlUtils.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/UrlUtils.kt
@@ -19,7 +19,7 @@ public object UrlUtils {
     public fun filePathToFileUrl(filePath: String): String? {
         return Arena.ofConfined().use { arena ->
             val result = ffiDownCall {
-                desktop_macos_h.url_file_path_to_file_url(arena.allocateUtf8String(filePath))
+                desktop_macos_h.url_file_path_to_file_url(arena.allocateFrom(filePath))
             }
             stringFromNullableNativePtr(result)
         }
@@ -36,7 +36,7 @@ public object UrlUtils {
     public fun urlToFilePath(url: String): String? {
         return Arena.ofConfined().use { arena ->
             val result = ffiDownCall {
-                desktop_macos_h.url_to_file_path(arena.allocateUtf8String(url))
+                desktop_macos_h.url_to_file_path(arena.allocateFrom(url))
             }
             stringFromNullableNativePtr(result)
         }
@@ -56,7 +56,7 @@ public object UrlUtils {
     public fun filePathToFileReferenceUrl(filePath: String): String? {
         return Arena.ofConfined().use { arena ->
             val result = ffiDownCall {
-                desktop_macos_h.url_file_path_to_file_reference_url(arena.allocateUtf8String(filePath))
+                desktop_macos_h.url_file_path_to_file_reference_url(arena.allocateFrom(filePath))
             }
             stringFromNullableNativePtr(result)
         }
@@ -64,7 +64,7 @@ public object UrlUtils {
 
     private fun stringFromNullableNativePtr(ptr: MemorySegment): String? {
         if (ptr == MemorySegment.NULL) return null
-        val str = ptr.getUtf8String(0)
+        val str = ptr.getString(0)
         ffiDownCall { desktop_macos_h.string_drop(ptr) }
         return str
     }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Window.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Window.kt
@@ -30,7 +30,7 @@ public class Window internal constructor(
             val nativeWindowParams = NativeWindowParams.allocate(arena)
             NativeWindowParams.origin(nativeWindowParams, origin.toNative(arena))
             NativeWindowParams.size(nativeWindowParams, size.toNative(arena))
-            NativeWindowParams.title(nativeWindowParams, arena.allocateUtf8String(title))
+            NativeWindowParams.title(nativeWindowParams, arena.allocateFrom(title))
 
             NativeWindowParams.is_resizable(nativeWindowParams, isResizable)
             NativeWindowParams.is_closable(nativeWindowParams, isClosable)
@@ -97,14 +97,14 @@ public class Window internal constructor(
         get() {
             val title = ffiDownCall { desktop_macos_h.window_get_title(pointer) }
             return try {
-                title.getUtf8String(0)
+                title.getString(0)
             } finally {
                 ffiDownCall { desktop_macos_h.string_drop(title) }
             }
         }
         set(value) {
             Arena.ofConfined().use { arena ->
-                val title = arena.allocateUtf8String(value)
+                val title = arena.allocateFrom(value)
                 ffiDownCall { desktop_macos_h.window_set_title(pointer, title) }
             }
         }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Application.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Application.kt
@@ -134,7 +134,7 @@ public class Application : AutoCloseable {
 public fun Application.Companion.openURL(url: String) {
     ffiDownCall {
         Arena.ofConfined().use { arena ->
-            desktop_win32_h.application_open_url(arena.allocateUtf8String(url))
+            desktop_win32_h.application_open_url(arena.allocateFrom(url))
         }
     }
 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Arrays.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Arrays.kt
@@ -11,7 +11,7 @@ import java.lang.foreign.ValueLayout.JAVA_INT
 
 internal fun ByteArray.toNative(arena: Arena): MemorySegment = let { bytes ->
     val result = NativeBorrowedArray_u8.allocate(arena)
-    NativeBorrowedArray_u8.ptr(result, arena.allocateArray(JAVA_BYTE, *bytes))
+    NativeBorrowedArray_u8.ptr(result, arena.allocateFrom(JAVA_BYTE, *bytes))
     NativeBorrowedArray_u8.len(result, bytes.count().toLong())
     result
 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Clipboard.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Clipboard.kt
@@ -163,7 +163,7 @@ public object Clipboard {
     public fun writeHtmlFragment(owner: Window, fragment: String) {
         owner.withPointer { windowPtr ->
             Arena.ofConfined().use { arena ->
-                val strPtr = arena.allocateUtf8String(fragment)
+                val strPtr = arena.allocateFrom(fragment)
                 ffiDownCall {
                     desktop_win32_h.clipboard_set_html_fragment(windowPtr, strPtr)
                 }
@@ -185,7 +185,7 @@ public object Clipboard {
     public fun writeTextItem(owner: Window, text: String) {
         owner.withPointer { windowPtr ->
             Arena.ofConfined().use { arena ->
-                val strPtr = arena.allocateUtf8String(text)
+                val strPtr = arena.allocateFrom(text)
                 ffiDownCall {
                     desktop_win32_h.clipboard_set_text(windowPtr, strPtr)
                 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataFormat.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataFormat.kt
@@ -16,7 +16,7 @@ public value class DataFormat internal constructor(internal val id: Int) {
         public fun register(formatName: String): DataFormat {
             val formatId = ffiDownCall {
                 Arena.ofConfined().use { arena ->
-                    val namePtr = arena.allocateUtf8String(formatName)
+                    val namePtr = arena.allocateFrom(formatName)
                     desktop_win32_h.data_transfer_register_format(namePtr)
                 }
             }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataObject.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataObject.kt
@@ -158,7 +158,7 @@ public class DataObjectBuilder internal constructor(private val dataObjectId: Lo
 
     public fun addHtmlFragment(fragment: String): Boolean {
         return Arena.ofConfined().use { arena ->
-            val strPtr = arena.allocateUtf8String(fragment)
+            val strPtr = arena.allocateFrom(fragment)
             ffiDownCall {
                 desktop_win32_h.data_object_add_from_html_fragment(dataObjectId, strPtr)
             }
@@ -176,7 +176,7 @@ public class DataObjectBuilder internal constructor(private val dataObjectId: Lo
 
     public fun addTextItem(text: String): Boolean {
         return Arena.ofConfined().use { arena ->
-            val strPtr = arena.allocateUtf8String(text)
+            val strPtr = arena.allocateFrom(text)
             ffiDownCall {
                 desktop_win32_h.data_object_add_from_text(dataObjectId, strPtr)
             }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Event.kt
@@ -69,7 +69,7 @@ public sealed class Event {
     ) : KeyEvent() {
         public fun toUnicode(): String = ffiDownCall {
             desktop_win32_h.keydown_to_unicode(originalMsgId)
-        }.getUtf8String(0)
+        }.getString(0)
     }
 
     @ConsistentCopyVisibility
@@ -417,6 +417,6 @@ private fun windowScaleChanged(s: MemorySegment): Event {
 private fun windowTitleChanged(s: MemorySegment): Event {
     val nativeEvent = NativeEvent.window_title_changed(s)
     return Event.WindowTitleChanged(
-        title = NativeWindowTitleChangedEvent.title(nativeEvent).getUtf8String(0),
+        title = NativeWindowTitleChangedEvent.title(nativeEvent).getString(0),
     )
 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/FileDialog.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/FileDialog.kt
@@ -31,7 +31,7 @@ public object FileDialog {
                 }
                 if (result != MemorySegment.NULL) {
                     try {
-                        result.getUtf8String(0).takeUnless { it.isEmpty() }
+                        result.getString(0).takeUnless { it.isEmpty() }
                     } finally {
                         ffiDownCall {
                             desktop_win32_h.native_string_drop(result)
@@ -67,16 +67,16 @@ public object FileDialog {
 
     internal fun FileDialogOptions.toNative(arena: Arena): MemorySegment {
         val result = NativeFileDialogOptions.allocate(arena)
-        NativeFileDialogOptions.title(result, title?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
-        NativeFileDialogOptions.prompt(result, prompt?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
-        NativeFileDialogOptions.name_field_label(result, nameFieldLabel?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
+        NativeFileDialogOptions.title(result, title?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
+        NativeFileDialogOptions.prompt(result, prompt?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
+        NativeFileDialogOptions.name_field_label(result, nameFieldLabel?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
         NativeFileDialogOptions.name_field_string_value(
             result,
             nameFieldStringValue?.let {
-                arena.allocateUtf8String(it)
+                arena.allocateFrom(it)
             } ?: MemorySegment.NULL,
         )
-        NativeFileDialogOptions.directory_path(result, directoryPath?.let { arena.allocateUtf8String(it) } ?: MemorySegment.NULL)
+        NativeFileDialogOptions.directory_path(result, directoryPath?.let { arena.allocateFrom(it) } ?: MemorySegment.NULL)
         NativeFileDialogOptions.shows_hidden_files(result, showsHiddenFiles)
         return result
     }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Logger.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Logger.kt
@@ -188,7 +188,7 @@ internal fun initLogger(logFile: Path, consoleLogLevel: LogLevel, fileLogLevel: 
         Arena.ofConfined().use { arena ->
             val configuration = NativeLoggerConfiguration.allocate(arena)
             val logFileStr = logFile.toAbsolutePath().toString()
-            NativeLoggerConfiguration.file_path(configuration, arena.allocateUtf8String(logFileStr))
+            NativeLoggerConfiguration.file_path(configuration, arena.allocateFrom(logFileStr))
             NativeLoggerConfiguration.console_level(configuration, consoleLogLevel.toNative())
             NativeLoggerConfiguration.file_level(configuration, fileLogLevel.toNative())
             desktop_win32_h.logger_init(configuration)
@@ -207,7 +207,7 @@ private fun checkExceptions(): List<String> {
         if (count != 0L) {
             (0 until count).map { i ->
                 val cStrPtr = items.getAtIndex(NativeExceptionsArray.`items$layout`(), i)
-                cStrPtr.getUtf8String(0)
+                cStrPtr.getString(0)
             }.toList()
         } else {
             emptyList()
@@ -244,6 +244,6 @@ internal inline fun <T> ffiUpCall(defaultResult: T, crossinline body: () -> T): 
 
 public fun outputDebugString(message: String) {
     Arena.ofConfined().use { arena ->
-        ffiDownCall { desktop_win32_h.logger_output_debug_string(arena.allocateUtf8String(message)) }
+        ffiDownCall { desktop_win32_h.logger_output_debug_string(arena.allocateFrom(message)) }
     }
 }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Screen.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Screen.kt
@@ -18,7 +18,7 @@ public data class Screen(
         internal fun fromNative(s: MemorySegment): Screen {
             return Screen(
                 isPrimary = NativeScreenInfo.is_primary(s),
-                name = NativeScreenInfo.name(s).getUtf8String(0),
+                name = NativeScreenInfo.name(s).getString(0),
                 origin = LogicalPoint.fromNative(NativeScreenInfo.origin(s)),
                 size = LogicalSize.fromNative(NativeScreenInfo.size(s)),
                 scale = NativeScreenInfo.scale(s),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Strings.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Strings.kt
@@ -16,7 +16,7 @@ internal fun listOfStringsFromNative(segment: MemorySegment): List<String> {
     return try {
         (0 until len).map { i ->
             val strPtr = ptr.getAtIndex(NativeAutoDropArray_RustAllocatedStrPtr.`ptr$layout`(), i)
-            strPtr.getUtf8String(0)
+            strPtr.getString(0)
         }.toList()
     } finally {
         ffiDownCall {
@@ -37,7 +37,7 @@ internal fun optionalListOfStringsFromNative(segment: MemorySegment): List<Strin
     return try {
         (0 until len).map { i ->
             val strPtr = ptr.getAtIndex(NativeAutoDropArray_RustAllocatedStrPtr.`ptr$layout`(), i)
-            strPtr.getUtf8String(0)
+            strPtr.getString(0)
         }.toList()
     } finally {
         ffiDownCall {
@@ -48,9 +48,9 @@ internal fun optionalListOfStringsFromNative(segment: MemorySegment): List<Strin
 
 internal fun listOfStringsToNative(arena: Arena, list: List<String>): MemorySegment {
     val itemsCount = list.count().toLong()
-    val itemsArray = arena.allocateArray(NativeBorrowedStrPtr, itemsCount)
+    val itemsArray = arena.allocate(NativeBorrowedStrPtr, itemsCount)
     list.forEachIndexed { index, item ->
-        val strPtr = arena.allocateUtf8String(item)
+        val strPtr = arena.allocateFrom(item)
         itemsArray.setAtIndex(NativeBorrowedStrPtr, index.toLong(), strPtr)
     }
     val result = NativeBorrowedArray_BorrowedStrPtr.allocate(arena)
@@ -62,7 +62,7 @@ internal fun listOfStringsToNative(arena: Arena, list: List<String>): MemorySegm
 internal fun stringFromNative(segment: MemorySegment): String {
     check(segment != MemorySegment.NULL) { "Native string was null" }
     return try {
-        segment.getUtf8String(0)
+        segment.getString(0)
     } finally {
         ffiDownCall {
             desktop_win32_h.native_string_drop(segment)
@@ -77,7 +77,7 @@ internal fun optionalStringFromNative(segment: MemorySegment): String? {
     }
     val strPtr = NativeFfiOption_RustAllocatedStrPtr.value(segment)
     return try {
-        strPtr.getUtf8String(0)
+        strPtr.getString(0)
     } finally {
         ffiDownCall {
             desktop_win32_h.native_optional_string_drop(segment)

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Window.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Window.kt
@@ -21,7 +21,7 @@ public data class WindowParams(
     internal fun toNative(arena: Arena): MemorySegment = NativeWindowParams.allocate(arena).also { nativeWindowParams ->
         NativeWindowParams.origin(nativeWindowParams, origin.toNative(arena))
         NativeWindowParams.size(nativeWindowParams, size.toNative(arena))
-        NativeWindowParams.title(nativeWindowParams, arena.allocateUtf8String(title))
+        NativeWindowParams.title(nativeWindowParams, arena.allocateFrom(title))
         NativeWindowParams.style(nativeWindowParams, style.toNative(arena))
     }
 }
@@ -161,7 +161,7 @@ public class Window internal constructor(
 
     public fun setCursorFromFile(path: Path) {
         Arena.ofConfined().use { arena ->
-            val nativePathString = arena.allocateUtf8String(path.toFile().absolutePath)
+            val nativePathString = arena.allocateFrom(path.toFile().absolutePath)
             ffiDownCall { desktop_win32_h.window_set_cursor_from_file(ptr, nativePathString) }
         }
     }
@@ -189,7 +189,7 @@ public class Window internal constructor(
 
     public fun setTitle(title: String) {
         Arena.ofConfined().use { arena ->
-            val nativeTitle = arena.allocateUtf8String(title)
+            val nativeTitle = arena.allocateFrom(title)
             ffiDownCall { desktop_win32_h.window_set_title(ptr, nativeTitle) }
         }
     }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -36,12 +36,8 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
-}
-
-tasks.compileJava {
-    options.compilerArgs = listOf("--enable-preview")
 }
 
 val depScope = configurations.dependencyScope("native") {
@@ -84,11 +80,10 @@ tasks.register<JavaExec>("runSkikoSampleMac") {
     mainClass.set("org.jetbrains.desktop.sample.macos.SkikoSampleMacKt")
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         },
     )
     jvmArgs = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
     )
@@ -105,11 +100,10 @@ tasks.register<JavaExec>("runApplicationMenuSampleMac") {
     mainClass.set("org.jetbrains.desktop.sample.macos.ApplicationMenuSampleMacKt")
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         },
     )
     jvmArgs = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
     )
@@ -126,11 +120,10 @@ tasks.register<JavaExec>("runSkikoSampleLinux") {
     mainClass.set("org.jetbrains.desktop.sample.linux.SkikoSampleLinuxKt")
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         },
     )
     jvmArgs = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
     )
@@ -144,11 +137,10 @@ tasks.register<JavaExec>("runSkikoSampleGtk") {
     mainClass.set("org.jetbrains.desktop.sample.gtk.SkikoSampleGtkKt")
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         },
     )
     jvmArgs = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
     )
@@ -177,11 +169,10 @@ tasks.register<JavaExec>("runSkikoSampleWin32") {
     mainClass.set("org.jetbrains.desktop.sample.win32.SkikoSampleWin32Kt")
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
         },
     )
     jvmArgs = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
         "-Dstdout.encoding=UTF-8",
@@ -241,7 +232,6 @@ tasks.jpackage {
     destination.set(layout.buildDirectory.dir("dist"))
 
     javaOptions = listOf(
-        "--enable-preview",
         "--enable-native-access=ALL-UNNAMED",
         "-Djextract.trace.downcalls=false",
         "-Dkdt.library.folder.path=\$APPDIR/native",


### PR DESCRIPTION
FFM was finalized in JDK 22, so the preview flags and the preview-era API names (allocateUtf8String/getUtf8String/allocateArray on SegmentAllocator) are no longer appropriate. Bump toolchains and CI to 25 and migrate call sites to the finalized API (allocateFrom/getString, allocate(layout, count) for count-allocations).