### PR TITLE
fix(macos): report enter and exit events for all windows in active app

### DIFF
--- a/native/desktop-macos/src/macos/window.rs
+++ b/native/desktop-macos/src/macos/window.rs
@@ -1008,7 +1008,7 @@ impl RootView {
     fn update_tracking_area_impl(&self, mtm: MainThreadMarker) {
         let rect = self.bounds();
         let options = NSTrackingAreaOptions::MouseEnteredAndExited
-            | NSTrackingAreaOptions::ActiveInKeyWindow
+            | NSTrackingAreaOptions::ActiveInActiveApp
             | NSTrackingAreaOptions::EnabledDuringMouseDrag
             | NSTrackingAreaOptions::CursorUpdate
             | NSTrackingAreaOptions::InVisibleRect


### PR DESCRIPTION
before that, mouse move was reported for key window even if it's not hovering it, and for non-key windows only on hover. Enter and exit events where reported only for key window.

See AIR-5008, there is a hypothesis that this inconsistency might make tooltips hang