### PR TITLE
feat(win32): caption strip follows immersive-dark flag

### DIFF
--- a/native/desktop-win32/docs/ARCHITECTURE.md
+++ b/native/desktop-win32/docs/ARCHITECTURE.md
@@ -226,6 +226,8 @@ Conventions:
                 │                                                 │
                 │  Input  : keyboard / pointer / cursor ◀─ event_loop dispatches
                 │  Display: screen / appearance         ◀─ on demand / WM_SETTINGCHANGE
+                │  Per-window chrome dark/light: DWMWA_USE_IMMERSIVE_DARK_MODE
+                │    cache on Window, set by app via setImmersiveDarkMode.
                 │  Geometry types are shared by everything that has coordinates.
                 │                                                 │
                 │  Data transfer:                                 │

--- a/native/desktop-win32/docs/SUBSYSTEMS.md
+++ b/native/desktop-win32/docs/SUBSYSTEMS.md
@@ -148,7 +148,7 @@ Per-subsystem reference. Each entry describes purpose, files, public API, key ty
 - Disabled visible Min/Max return `HTCAPTION` for `WM_NCHITTEST`. The OS therefore sends `WM_NCLBUTTONDOWN` with `wparam = HTCAPTION`; `on_nclbuttondown`'s HTCAPTION arm re-hit-tests via `caption_kind_at_screen` and swallows the click (creates `PrimaryPress { suppressed: true }` + SetCapture). The matching release drains via `WM_LBUTTONUP` → `on_lbuttonup` → no action fires. No hover, press, or Kotlin event for disabled clicks — see spec §4.2.
 - `root_visual`, `chrome_layer`, `backdrop_layer`, and the backdrop tint `SpriteVisual` carry `RelativeSizeAdjustment(1,1)` set in `initialize_content`; per-resize `SetSize` is not required. `content_layer` is left at default — the ANGLE visual sets its own absolute `Size` and no other child reads the parent's effective size. The strip's `on_resize` is the single commit point per resize tick — see spec §5.5.
 
-**Cross-refs.** `window` (`chrome_layer` parent, `Window::set_content_top_offset`, `Window::with_strip[_mut]` accessor), `event_loop` (wndproc dispatch into `caption_kind_at_screen`, `dispatch_caption_action`, `notify_strip_appearance_refresh`, and the strip's lifecycle methods), `appearance` (`Appearance` / `HighContrast` seed values + change events), `geometry` (`PhysicalPoint` / `PhysicalSize`).
+**Cross-refs.** `window` (`chrome_layer` parent, `Window::set_content_top_offset`, `Window::with_strip[_mut]` accessor), `event_loop` (wndproc dispatch into `caption_kind_at_screen`, `dispatch_caption_action`, and the strip's lifecycle methods), `appearance` (the strip's `Appearance` mirrors the per-window `DWMWA_USE_IMMERSIVE_DARK_MODE` cache; `HighContrast` is seeded from the system and refreshed on system events), `geometry` (`PhysicalPoint` / `PhysicalSize`).
 
 ---
 
@@ -310,7 +310,7 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 
 ## Appearance
 
-**Purpose.** Detect system appearance state used by window chrome and caption-button rendering: light/dark theme plus high-contrast On/Off.
+**Purpose.** Detect the system's light/dark theme and high-contrast On/Off state. The light/dark theme is forwarded to Kotlin as `SystemAppearanceChangeEvent`. Per-window chrome dark/light is controlled separately by `DWMWA_USE_IMMERSIVE_DARK_MODE` — see the `window` subsystem. High-contrast feeds the caption-button strip palette and refreshes whenever Windows reports a high-contrast change.
 
 **Files.** `appearance.rs`, `appearance_api.rs` + Kotlin `Appearance.kt`.
 
@@ -326,7 +326,7 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 **Gotchas.**
 - High-contrast changes can produce both `WM_SETTINGCHANGE` (`SPI_SETHIGHCONTRAST`) and `WM_SYSCOLORCHANGE`; the toolkit intentionally treats events as idempotent snapshots.
 - `WM_SETTINGCHANGE` is broadcast per-window, so the appearance event fires once per window. Apps with multiple windows see N redundant events for one OS change.
-- No registry / `DwmSetWindowAttribute` consultation here — DWM titlebar tinting is handled in `window.rs` / `event_loop.rs`, not in `appearance.rs`.
+- No registry / `DwmSetWindowAttribute` consultation here — DWM titlebar tinting is handled in `window.rs` (the `set_immersive_dark_mode` call site), not in `appearance.rs`.
 
 **Cross-refs.** `events` (`SystemAppearanceChangeEvent`), `event_loop` (`on_settingchange`), `window` (DWM dark titlebar), WinRT `Windows.UI.ViewManagement`.
 

--- a/native/desktop-win32/docs/specs/2026-04-30-win32-caption-buttons-design.md
+++ b/native/desktop-win32/docs/specs/2026-04-30-win32-caption-buttons-design.md
@@ -49,7 +49,7 @@ Three crate-internal modules, all `pub(crate)` only — no FFI surface, no `_api
   - `WM_CANCELMODE` and `WM_ACTIVATE`-deactivate call `strip.cancel_any_press()` (no `pointer_id` available) and return `None`. [`WM_CANCELMODE`](https://learn.microsoft.com/windows/win32/winmsg/wm-cancelmode) doc says `DefWindowProc` "cancels internal processing of standard scroll bar input, cancels internal menu processing, and releases the mouse capture" — letting it run preserves that. These arms backstop focus-loss paths Windows does not deliver `WM_POINTERCAPTURECHANGED` on (ALT-TAB, `EnableWindow(FALSE)`, RDP disconnect).
   - `TrackMouseEvent(TME_NONCLIENT | TME_LEAVE)` is armed when an NC pointer update enters the window non-client area, not when it enters a specific caption button.
   - `on_ncmouseleave` calls `strip.on_nc_mouse_leave()` and `window.nc_leave_tracking_fired()` before the `DwmDefWindowProc` pass-through.
-  - `on_dpichanged` and `on_settingchange` call the strip's invalidation methods. `WM_DPICHANGED` calls `Window::set_dpi_metrics(new_dpi)` (wparam-derived) before any nested handler runs so downstream readers consume the freshly cached metrics without re-syscalling.
+  - `on_dpichanged` calls the strip's DPI invalidation (`on_dpi_change`). `on_settingchange` and `on_syscolorchange` forward high-contrast updates to the strip via `on_high_contrast_change`; the `WM_SETTINGCHANGE/ImmersiveColorSet` branch raises `SystemAppearanceChangeEvent` to Kotlin only; strip dark/light is app-driven via `setImmersiveDarkMode`. `WM_DPICHANGED` calls `Window::set_dpi_metrics(new_dpi)` (wparam-derived) before any nested handler runs so downstream readers consume the freshly cached metrics without re-syscalling.
   - `on_windowposchanged` calls `strip.on_max_state_change(IsZoomed(hwnd).as_bool())` when the cached maximize state has changed. `on_windowposchanged` returns `Some(LRESULT(0))`; no separate `WM_SIZE` arm. [`IsZoomed`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-iszoomed) is the documented Win32 API for checking maximized state.
   - `on_nccalcsize` (a) applies the maximized client-area inset described in §3.6 *before* emitting `NCCalcSizeEvent`, and (b) calls `strip.on_resize(max_chrome_y)` after the inset-aware client-rect calculation. Strip mutations queue; the driver's `CommitNeeded` fast-path publishes inline on the UI thread before the wndproc returns. The backdrop tint `SpriteVisual` auto-tracks via `RelativeSizeAdjustment(1,1)` and does not require a per-tick `SetSize`.
 
@@ -239,19 +239,32 @@ pub fn on_nc_mouse_leave(&mut self);
 // Theming / state changes
 pub fn on_activate(&mut self, is_active: bool);
 pub fn on_dpi_change(&mut self, new_scale: f32, max_chrome_y: i32) -> anyhow::Result<()>;
-pub fn on_appearance_change(&mut self, appearance: Appearance, high_contrast: HighContrast);
+pub fn on_appearance_change(&mut self, appearance: Appearance);
+pub fn on_high_contrast_change(&mut self, high_contrast: HighContrast);
 pub fn on_rendering_device_replaced(&mut self);
 pub fn on_max_state_change(&mut self, is_maximized: bool);
 pub fn on_resize(&mut self, max_chrome_y: i32);
 ```
 
-`CaptionButtonStrip::new` seeds `appearance` and `high_contrast` from `Appearance::get_current()` and `HighContrast::get_current()`. Both queries are non-fatal: a failed query logs at warning level and falls back to `Appearance::Light` / `HighContrast::Off`, and the strip self-corrects on the next appearance event.
+`CaptionButtonStrip::new` takes `initial_appearance: Appearance` from the caller.
+
+On window create (`initialize_window`), `Window` always passes `Appearance::Light`. The `immersive_dark` cache is seeded to `false` in `Window::new`, and `setImmersiveDarkMode` cannot run before `window_create` returns, so the cache is guaranteed `false` at this point.
+
+On strip rebuild (`rebuild_caption_strip`, triggered by `WindowStyle` mutations after the window has been created), `Window` reads the cache and passes the current value.
+
+`high_contrast` is seeded from `HighContrast::get_current()`. If the initial query fails the strip falls back to `HighContrast::Off` and logs a warning; the next `WM_SETTINGCHANGE` or `WM_SYSCOLORCHANGE` reseeds the correct value.
+
+`setImmersiveDarkMode` is a no-op on Windows builds below 11 22000. On those builds DWM ignores `DWMWA_USE_IMMERSIVE_DARK_MODE`, so the system-drawn title-bar background stays light no matter what the app requests. The cache is left at `false` so the caption-button strip stays light too, matching the title-bar background.
+
+The cache lives on `Window` as `immersive_dark: Cell<bool>`. The [`DWMWINDOWATTRIBUTE`](https://learn.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) enum documents `DWMWA_USE_IMMERSIVE_DARK_MODE` as a set-only attribute, so there is no reliable `DwmGetWindowAttribute` call to read the current value back from DWM — the toolkit has to remember it.
+
+The cache is updated only after `DwmSetWindowAttribute` succeeds, so it reflects the state DWM actually applied rather than what the app most recently requested. `set_immersive_dark_mode` short-circuits when the requested value already matches the cache; that short-circuit is safe only because a failed syscall leaves the cache unchanged, which lets a retry with the same value run the syscall again.
 
 The strip never invokes `Window::request_close` and friends directly — it returns `CaptionButtonAction` and the wndproc dispatches. This keeps the strip independent of `Window`'s broader state and unit-testable in isolation.
 
 ### 4.3 `CaptionButton` (private to `caption_buttons.rs`)
 
-Each button holds a `backplate: SpriteVisual` with a `CompositionColorBrush` and a `glyph: SpriteVisual` whose brush is a `CompositionMaskBrush` combining a `CompositionSurfaceBrush` (wrapping the pre-rasterised `glyph_surface`) as `Mask` with a `CompositionColorBrush` as `Source`. State transitions only mutate the `Source` colour; glyph re-rasterisation happens only on DPI / theme / high-contrast / max-state changes.
+Each button holds a `backplate: SpriteVisual` with a `CompositionColorBrush` and a `glyph: SpriteVisual` whose brush is a `CompositionMaskBrush` combining a `CompositionSurfaceBrush` (wrapping the pre-rasterised `glyph_surface`) as `Mask` with a `CompositionColorBrush` as `Source`. State transitions only mutate the `Source` colour; glyph re-rasterisation happens only on DPI, high-contrast, and max-state changes; light/dark appearance changes only swap the palette.
 
 The intermediate `CompositionSurfaceBrush` / `CompositionMaskBrush` aren't stored — `SpriteVisual.SetBrush(&mask_brush)` keeps the chain alive. Surface format is BGRA8 premultiplied.
 
@@ -347,8 +360,8 @@ Sourced from `microsoft/terminal:MinMaxCloseControl.xaml` `CommonStates` `Visual
 | `WM_NCMOUSELEAVE` | `on_nc_mouse_leave()`; window clears tracking armed | cheap |
 | `WM_NCCALCSIZE` (after client-rect calc) | `set_content_top_offset(max_chrome_y)`; `Custom` calls `on_resize(max_chrome_y)`. `CommitNeeded` fast-path publishes inline. | cheap |
 | `WM_DPICHANGED` | `set_dpi_metrics(new_dpi)` first; `Custom`: `set_content_top_offset` → `on_dpi_change(scale, max_chrome_y)` | **expensive** (re-rasterise all glyph surfaces) |
-| `Appearance` event | `on_appearance_change(appearance, hc)` | **expensive iff foreground-rest colour changed** |
-| `HighContrast` event | same as above with new `hc` | **expensive** (glyph code points swap E921↔EF2D etc.) |
+| `setImmersiveDarkMode` call | `on_appearance_change(appearance)` | cheap (palette swap only; glyph surfaces untouched) |
+| `HighContrast` event (`WM_SETTINGCHANGE/SPI_SETHIGHCONTRAST` or `WM_SYSCOLORCHANGE`) | `on_high_contrast_change(hc)` | **expensive** (glyph code points swap E921↔EF2D etc.; full glyph re-raster) |
 | `WM_ACTIVATE` | `on_activate(is_active)`; deactivate also calls `cancel_any_press()` | cheap (theme re-resolve, brush updates) |
 | `WM_WINDOWPOSCHANGED` | `Custom`: `on_max_state_change(is_maximized)` | **expensive for Maximize button only** on actual transitions (E922 ↔ E923) |
 

--- a/native/desktop-win32/src/win32/caption_buttons.rs
+++ b/native/desktop-win32/src/win32/caption_buttons.rs
@@ -334,24 +334,6 @@ pub(crate) const fn hittest_for_caption_button_kind(kind: CaptionButtonKind, is_
     }
 }
 
-/// Refresh the strip's appearance after a system appearance or high-contrast change.
-///
-/// Pass the known half as `Some`; the function queries the current value for whichever
-/// parameter is `None`. Defaults to `Appearance::Light` / `HighContrast::Off` on query failure.
-pub(crate) fn notify_strip_appearance_refresh(window: &Window, override_appearance: Option<Appearance>, override_hc: Option<HighContrast>) {
-    let appearance = override_appearance.unwrap_or_else(|| {
-        Appearance::get_current()
-            .inspect_err(|err| log::warn!("strip appearance notify: failed to read appearance: {err}"))
-            .unwrap_or(Appearance::Light)
-    });
-    let hc = override_hc.unwrap_or_else(|| {
-        HighContrast::get_current()
-            .inspect_err(|err| log::warn!("strip appearance notify: failed to read high-contrast state: {err}"))
-            .unwrap_or(HighContrast::Off)
-    });
-    window.with_strip_mut(|strip| strip.on_appearance_change(appearance, hc));
-}
-
 /// Dispatch a resolved `CaptionButtonAction` to the corresponding `Window` method.
 pub(crate) fn dispatch_caption_action(window: &Window, action: CaptionButtonAction) {
     match action {
@@ -468,6 +450,7 @@ impl CaptionButtonStrip {
         hwnd: HWND,
         initial_is_active: bool,
         initial_is_maximized: bool,
+        initial_appearance: Appearance,
         initial_top_offset_px: i32,
     ) -> anyhow::Result<Self> {
         let composition_context = crate::win32::composition::ensure_composition_context(compositor.clone())?;
@@ -511,9 +494,7 @@ impl CaptionButtonStrip {
             .SetAnchorPoint(Vector2::new(1.0, 0.0))
             .inspect_err(|err| log::warn!("composition_root SetAnchorPoint failed: {err}"))?;
 
-        let appearance = Appearance::get_current()
-            .inspect_err(|err| log::warn!("CaptionButtonStrip: failed to read initial appearance, defaulting to Light: {err}"))
-            .unwrap_or(Appearance::Light);
+        // If the initial query fails we fall back to `Off`; the next `WM_SETTINGCHANGE` or `WM_SYSCOLORCHANGE` reseeds the correct value.
         let high_contrast = HighContrast::get_current()
             .inspect_err(|err| log::warn!("CaptionButtonStrip: failed to read initial high-contrast state, defaulting to Off: {err}"))
             .unwrap_or(HighContrast::Off);
@@ -524,7 +505,7 @@ impl CaptionButtonStrip {
             visible_kinds,
             is_active: initial_is_active,
             is_window_maximized: initial_is_maximized,
-            appearance,
+            appearance: initial_appearance,
             high_contrast,
             metrics,
             pointer_over_kind: None,
@@ -817,14 +798,23 @@ impl CaptionButtonStrip {
         Ok(())
     }
 
-    pub fn on_appearance_change(&mut self, appearance: Appearance, hc: HighContrast) {
-        let glyph_invalidate = self.high_contrast != hc;
+    /// Glyph surfaces deliberately untouched: only the palette varies on this axis.
+    pub fn on_appearance_change(&mut self, appearance: Appearance) {
+        if self.appearance == appearance {
+            return;
+        }
         self.appearance = appearance;
+        self.apply_visuals_to_all_buttons();
+    }
+
+    /// Dirties every glyph surface: HC swaps glyph code points / fill style alongside the palette.
+    pub fn on_high_contrast_change(&mut self, hc: HighContrast) {
+        if self.high_contrast == hc {
+            return;
+        }
         self.high_contrast = hc;
-        if glyph_invalidate {
-            for button in &mut self.buttons {
-                button.glyph_surface_dirty = true;
-            }
+        for button in &mut self.buttons {
+            button.glyph_surface_dirty = true;
         }
         self.apply_visuals_to_all_buttons();
     }

--- a/native/desktop-win32/src/win32/event_loop.rs
+++ b/native/desktop-win32/src/win32/event_loop.rs
@@ -41,7 +41,7 @@ use super::{
     appearance::{Appearance, HighContrast},
     caption_buttons::{
         CaptionButtonKind, CaptionButtonStrip, PointerDeviceKind, WM_APP_CAPTION_BUTTONS_RENDERING_DEVICE_REPLACED, caption_kind_at_screen,
-        device_kind_for, dispatch_caption_action, hittest_for_caption_button_kind, notify_strip_appearance_refresh,
+        device_kind_for, dispatch_caption_action, hittest_for_caption_button_kind,
     },
     events::{
         CharacterReceivedEvent, Event, EventHandler, KeyEvent, NCCalcSizeEvent, NCHitTestEvent, PointerDownEvent, PointerEnteredEvent,
@@ -331,7 +331,6 @@ fn on_settingchange(event_loop: &EventLoop, window: &Window, wparam: WPARAM, lpa
                 Ok(new_appearance) => {
                     let event = SystemAppearanceChangeEvent { new_appearance };
                     event_loop.handle_event(window, event);
-                    notify_strip_appearance_refresh(window, Some(new_appearance), None);
                 }
                 Err(err) => log::error!("failed to get current system appearance: {err}"),
             }
@@ -342,7 +341,7 @@ fn on_settingchange(event_loop: &EventLoop, window: &Window, wparam: WPARAM, lpa
             Ok(new_high_contrast) => {
                 let event = SystemHighContrastChangeEvent { new_high_contrast };
                 event_loop.handle_event(window, event);
-                notify_strip_appearance_refresh(window, None, Some(new_high_contrast));
+                window.with_strip_mut(|strip| strip.on_high_contrast_change(new_high_contrast));
             }
             Err(err) => log::error!("failed to get high-contrast state: {err}"),
         }
@@ -361,7 +360,7 @@ fn on_syscolorchange(event_loop: &EventLoop, window: &Window) -> Option<LRESULT>
         .ok()?;
     let event = SystemHighContrastChangeEvent { new_high_contrast };
     event_loop.handle_event(window, event);
-    notify_strip_appearance_refresh(window, None, Some(new_high_contrast));
+    window.with_strip_mut(|strip| strip.on_high_contrast_change(new_high_contrast));
     None
 }
 

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -41,6 +41,7 @@ use windows::{
 use windows_core::{HSTRING, Interface, PCWSTR, Result as WinResult, w};
 
 use super::{
+    appearance::Appearance,
     caption_buttons::CaptionButtonStrip,
     cursor::{Cursor, CursorIcon},
     event_loop::EventLoop,
@@ -122,6 +123,7 @@ pub struct Window {
     cached_dpi_metrics: Cell<DpiMetrics>,
     system_menu: Cell<HMENU>,
     caption_buttons: RefCell<Option<CaptionButtonStrip>>,
+    immersive_dark: Cell<bool>,
     pointer_click_counter: RefCell<PointerClickCounter>,
     cursor: RefCell<Option<Cursor>>,
     backdrop_tint: RefCell<Option<SpriteVisual>>,
@@ -161,6 +163,7 @@ impl Window {
             cached_dpi_metrics: Cell::new(DpiMetrics::for_dpi(USER_DEFAULT_SCREEN_DPI)),
             system_menu: Cell::new(HMENU::default()),
             caption_buttons: RefCell::new(None),
+            immersive_dark: Cell::new(false),
             pointer_click_counter: RefCell::new(PointerClickCounter::new()),
             cursor: RefCell::new(None),
             backdrop_tint: RefCell::new(None),
@@ -513,21 +516,24 @@ impl Window {
     }
 
     pub fn set_immersive_dark_mode(&self, enabled: bool) -> WinResult<()> {
-        if utils::is_windows_11_build_22000_or_higher() {
-            let enablement = if enabled {
-                windows::Win32::Foundation::TRUE
-            } else {
-                windows::Win32::Foundation::FALSE
-            };
-            unsafe {
-                DwmSetWindowAttribute(
-                    self.hwnd(),
-                    DWMWA_USE_IMMERSIVE_DARK_MODE,
-                    (&raw const enablement).cast(),
-                    size_of::<windows_core::BOOL>().try_into()?,
-                )?;
-            }
+        if !utils::is_windows_11_build_22000_or_higher() {
+            return Ok(());
         }
+        if self.immersive_dark.get() == enabled {
+            return Ok(());
+        }
+        let enablement = windows_core::BOOL::from(enabled);
+        unsafe {
+            DwmSetWindowAttribute(
+                self.hwnd(),
+                DWMWA_USE_IMMERSIVE_DARK_MODE,
+                (&raw const enablement).cast(),
+                size_of::<windows_core::BOOL>().try_into()?,
+            )?;
+        }
+        self.immersive_dark.set(enabled);
+        let appearance = if enabled { Appearance::Dark } else { Appearance::Light };
+        self.with_strip_mut(|strip| strip.on_appearance_change(appearance));
         Ok(())
     }
 
@@ -584,6 +590,11 @@ impl Window {
         }
         let chrome_layer = self.chrome_layer()?;
         let is_active = unsafe { GetForegroundWindow() == self.hwnd() };
+        let initial_appearance = if self.immersive_dark.get() {
+            Appearance::Dark
+        } else {
+            Appearance::Light
+        };
         let new_strip = CaptionButtonStrip::new(
             &chrome_layer,
             self.get_scale(),
@@ -592,6 +603,7 @@ impl Window {
             self.hwnd(),
             is_active,
             self.is_maximized(),
+            initial_appearance,
             self.max_chrome_y(),
         )?;
         self.caption_buttons.replace(Some(new_strip));
@@ -789,6 +801,7 @@ fn initialize_window(window: &Window, hwnd: HWND) -> anyhow::Result<()> {
             hwnd,
             false,
             false,
+            Appearance::Light,
             0,
         )?;
         window.caption_buttons.replace(Some(strip));


### PR DESCRIPTION
## Summary
- Caption-button strip dark/light tracks the per-window `DWMWA_USE_IMMERSIVE_DARK_MODE` flag instead of the global system theme, keeping the toolkit-owned chrome in sync with the DWM-drawn title-bar background.
- `CaptionButtonStrip::on_appearance_change(Appearance, HighContrast)` splits into `on_appearance_change(Appearance)` and `on_high_contrast_change(HighContrast)`; HC continues to track the system, only light/dark is app-driven.
- Apps that want to follow the system light/dark theme call `setImmersiveDarkMode` from their `SystemAppearanceChange` event handler (the sample already does).

## Test plan
- [x] Manual: sample on dark-themed Windows — title bar + caption-button strip both render dark from first paint.
- [x] Manual: sample on light-themed Windows — both render light.
- [x] Manual: toggle the OS light/dark theme while sample is running — both update together.
- [x] Manual: toggle OS high-contrast on/off while sample is running — strip palette swaps glyph fills; immersive-dark cache untouched.
- [x] Manual: trigger a strip rebuild (e.g. flip `setIsResizable`) on a dark-themed window — strip stays dark after rebuild.
- [x] Pre-merge: `./gradlew lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)