### PR TITLE
feat(win32): dark system-menu popup

### DIFF
--- a/native/desktop-win32/docs/specs/2026-05-27-win32-dark-system-menu-design.md
+++ b/native/desktop-win32/docs/specs/2026-05-27-win32-dark-system-menu-design.md
@@ -6,7 +6,7 @@
 
 Make the native `HMENU` system-menu popup honour Windows 11's dark theme. The popup opens from `WindowTitleBarKind::Custom` and `WindowTitleBarKind::None` windows via Alt+Space and a right-click on the title bar (see [2026-05-26-win32-system-menu-restoration-design.md](2026-05-26-win32-system-menu-restoration-design.md)). By default it paints with the classic light `COLOR_MENU` palette regardless of the system theme.
 
-To recolour it, drive the OS's immersive dark-mode pipeline through the undocumented `uxtheme.dll` ordinal #135 `SetPreferredAppMode` — the same mechanism Chromium ([`base/win/dark_mode_support.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/win/dark_mode_support.cc)), Edge, Electron, WinAppSDK, and the Windows Settings app rely on. Each `Window.setImmersiveDarkMode(enabled)` call sets `PreferredAppMode::ForceDark` when `enabled`, `ForceLight` otherwise; the next `TrackPopupMenu` paints the popup in that colour.
+To recolour it, drive the OS's immersive dark-mode pipeline through the undocumented `uxtheme.dll` ordinal #135 `SetPreferredAppMode` — the same mechanism Chromium ([`base/win/dark_mode_support.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/win/dark_mode_support.cc)), Edge, Electron, WinAppSDK, and the Windows Settings app rely on. The mode is process-global, so each window's menu is themed at the moment it opens: the popup path forces `ForceDark`/`ForceLight` to match the opening window's own state, shows the menu, then restores the prior mode.
 
 ### What this design is NOT
 
@@ -20,7 +20,7 @@ Two independent Windows APIs govern the two surfaces (popup and title-bar frame)
 
 | API | Scope | Documented? | Role |
 |-----|-------|-------------|------|
-| `SetPreferredAppMode(Force*)` — `uxtheme.dll` ordinal #135 | Process | No | Sole governor of the `HMENU` popup colour; paired with `FlushMenuThemes` (#136) so already-open menus pick up a change (§3.1). |
+| `SetPreferredAppMode(Force*)` — `uxtheme.dll` ordinal #135 | Process | No | Sole governor of the `HMENU` popup colour. Scoped around each `TrackPopupMenu` and paired with `FlushMenuThemes` (#136) so the menu re-themes for the opening window (§3, §4). |
 | `DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE, …)` | Per HWND | Yes (Win11 22000+) | Governs the title-bar dark frame only. Called from [`Window::set_immersive_dark_mode`](../../src/win32/window.rs). |
 
 The popup remains a native `HMENU`: same handle, same hit-testing, same accessibility tree, same `TrackPopupMenu` codepath.
@@ -28,24 +28,25 @@ The popup remains a native `HMENU`: same handle, same hit-testing, same accessib
 ### Caveats
 
 - **The ordinals are undocumented.** Microsoft's [undocumented-APIs policy](https://learn.microsoft.com/windows/compatibility/undocumented-apis) warns against ordinal lookups, but #135 and #136 have been stable since Windows 10 1903 across the consumers named in §1. Resolution failure is non-fatal (§6); worst case, the menu stays light.
-- **`SetPreferredAppMode` is process-wide.** Calling `set_immersive_dark_mode` on any window flips the popup mode for every menu opened by the process. A multi-window app with mixed light and dark windows therefore sees last-call-wins on popup colour; every call re-asserts the mode for its window's appearance, so a window can reclaim the popup colour at any time (`set_immersive_dark_mode` does not early-return on an unchanged state). Title-bar frames stay correct per window because the DWM bit is per-HWND. A follow-up in §9 describes how to scope the mode per popup so concurrent windows no longer contend.
+- **`SetPreferredAppMode` is process-global.** The popup path forces the opening window's mode only for the duration of its `TrackPopupMenu` and restores the prior mode afterward, so each window's menu matches that window and the process is left as it was found. `TrackPopupMenu` is modal, so two windows never theme a menu at once. Title-bar frames are independent — the DWM bit is per-HWND.
 - **`ForceDark` / `ForceLight` ignore the system theme.** The popup colour follows the Kotlin caller, not the user's Windows theme setting.
 - **The popup is not visually Windows 11.** It is a classic flat menu — no Mica, no rounded corners, no reveal animation. Those treatments exist only on XAML `MenuFlyout`, not on native HMENU.
 
 ## 3. Module layout
 
-The code lives in [`appearance.rs`](../../src/win32/appearance.rs) alongside the `Appearance` and `HighContrast` types, exposing one `pub(crate)` entry point:
+The code lives in [`appearance.rs`](../../src/win32/appearance.rs) alongside the `Appearance` and `HighContrast` types, exposing one `pub(crate)` entry point — a scope function that forces a menu palette for the duration of a closure:
 
 ```rust
-pub(crate) fn set_preferred_app_mode(appearance: Appearance);
+pub(crate) fn with_preferred_app_mode<R>(appearance: Appearance, f: impl FnOnce() -> R) -> R;
 ```
 
 ### 3.1 Internal state
 
 ```rust
 type RawProcFn = unsafe extern "system" fn() -> isize;
-// Returns the previous mode as `i32`, not `PreferredAppMode`: an out-of-range enum from FFI would be UB.
-type SetPreferredAppModeFn = unsafe extern "system" fn(PreferredAppMode) -> i32;
+// Raw `i32` both ways: pass `PreferredAppMode as i32` going in, feed the returned previous
+// mode straight back when restoring, without rebuilding a `#[repr(i32)]` enum from it.
+type SetPreferredAppModeFn = unsafe extern "system" fn(i32) -> i32;
 type FlushMenuThemesFn = unsafe extern "system" fn();
 
 #[repr(i32)]
@@ -59,25 +60,45 @@ enum PreferredAppMode {
 }
 ```
 
-Both pointers are resolved once and cached together in a function-scoped `static OnceLock<Option<UxThemeFns>>` (the `UxThemeFns` struct and its loader follow in §3.2). Resolution is all-or-nothing: #135 and #136 shipped together in Windows 10 1903, below our 22000 gate, so they are present as a pair. `SetPreferredAppMode` flips the *process* preferred mode but leaves an already-opened menu — including the cached per-window system-menu `HMENU` — painted in its previous theme. `FlushMenuThemes` (ordinal #136) drops that cached menu theme so the next `TrackPopupMenu` re-themes; it is called immediately after every `SetPreferredAppMode`.
+Both pointers are resolved once and cached together in a function-scoped `static OnceLock<Option<UxThemeFns>>` (the `UxThemeFns` struct and its loader follow in §3.2). Resolution is all-or-nothing: #135 and #136 shipped together in Windows 10 1903, below our 22000 gate, so they are present as a pair. `SetPreferredAppMode` flips the *process* preferred mode, and `FlushMenuThemes` (ordinal #136) drops the cached menu theme so the next `TrackPopupMenu` re-themes. The guard in §3.2 pairs them: it forces a mode and flushes on creation, then restores the previous mode and flushes again on drop.
 
-### 3.2 `set_preferred_app_mode`
+### 3.2 `with_preferred_app_mode` and the scope guard
+
+`with_preferred_app_mode` runs a closure with the menu palette forced to `appearance`. A private RAII guard forces the mode (and flushes) when constructed and restores the previous mode (and flushes) on drop, so the closure — the `TrackPopupMenu` call — sees the forced palette and the process mode is left as it was.
 
 ```rust
-pub(crate) fn set_preferred_app_mode(appearance: Appearance) {
-    let Some(fns) = ux_theme_fns() else {
-        return;
-    };
-    let mode = match appearance {
-        Appearance::Dark => PreferredAppMode::ForceDark,
-        Appearance::Light => PreferredAppMode::ForceLight,
-    };
-    unsafe { (fns.set_preferred_app_mode)(mode) };
-    // SetPreferredAppMode leaves already-themed menus on their old cache; flush so
-    // the next TrackPopupMenu re-themes the system-menu HMENU.
-    unsafe { (fns.flush_menu_themes)() };
+struct PreferredAppModeGuard {
+    fns: &'static UxThemeFns,
+    previous: i32,
+}
+
+impl PreferredAppModeGuard {
+    fn set(appearance: Appearance) -> Option<Self> {
+        let fns = ux_theme_fns()?;
+        let mode = match appearance {
+            Appearance::Dark => PreferredAppMode::ForceDark,
+            Appearance::Light => PreferredAppMode::ForceLight,
+        };
+        let previous = unsafe { (fns.set_preferred_app_mode)(mode as i32) };
+        unsafe { (fns.flush_menu_themes)() };
+        Some(Self { fns, previous })
+    }
+}
+
+impl Drop for PreferredAppModeGuard {
+    fn drop(&mut self) {
+        unsafe { (self.fns.set_preferred_app_mode)(self.previous) };
+        unsafe { (self.fns.flush_menu_themes)() };
+    }
+}
+
+pub(crate) fn with_preferred_app_mode<R>(appearance: Appearance, f: impl FnOnce() -> R) -> R {
+    let _guard = PreferredAppModeGuard::set(appearance);
+    f()
 }
 ```
+
+When uxtheme is unavailable (pre-22000, resolution failure) `set` returns `None` and the closure still runs, so the menu opens unthemed.
 
 The version probe, single DLL load, and per-ordinal resolution sit in `ux_theme_fns`, which caches the pair in one `OnceLock` and returns `None` unless both resolve:
 
@@ -128,20 +149,18 @@ fn resolve_ordinal(module: HMODULE, n: u16, name: &str) -> Option<RawProcFn> {
 
 ## 4. Wire-up — [`window.rs`](../../src/win32/window.rs)
 
-`Window::set_immersive_dark_mode` toggles `DWMWA_USE_IMMERSIVE_DARK_MODE`, derives an `Appearance` from the new state, and propagates it to the caption-button strip. The popup-mode call joins that pipeline at the same point:
+`show_system_menu` owns the popup colour. It reads the window's dark/light state — `self.immersive_dark`, maintained by the existing `set_immersive_dark_mode` alongside the DWM frame and caption strip — and wraps just the `TrackPopupMenu` call, so the menu is themed from the window that opened it. `GetLastError` is read inside the closure, before the guard's restore runs (which calls `SetPreferredAppMode` again and sets the last error):
 
 ```rust
-pub fn set_immersive_dark_mode(&self, enabled: bool) -> WinResult<()> {
-    // …existing DWM toggle…
-    let appearance = if enabled { Appearance::Dark } else { Appearance::Light };
-    self.with_strip_mut(|strip| strip.on_appearance_change(appearance));
-    appearance::set_preferred_app_mode(appearance);
-    self.immersive_dark.set(enabled); // commit state after the side effects land
-    Ok(())
-}
+let appearance = if self.immersive_dark.get() { Appearance::Dark } else { Appearance::Light };
+let (cmd, last_error) = appearance::with_preferred_app_mode(appearance, || {
+    unsafe { SetLastError(WIN32_ERROR(0)) };
+    let cmd = unsafe {
+        TrackPopupMenu(h_menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, screen_pt.x.0, screen_pt.y.0, None, hwnd, None)
+    };
+    (cmd, unsafe { GetLastError() })
+});
 ```
-
-The process-wide mode flip happens whenever a Kotlin caller sets immersive dark/light on a window — `set_immersive_dark_mode` no longer early-returns on an unchanged state, so a window always re-asserts its popup colour (the caption strip still skips repainting when the appearance is unchanged).
 
 ## 5. Cargo.toml
 
@@ -154,14 +173,14 @@ No new dependencies. The imports come from the `windows` features already enable
 
 ## 6. Error handling
 
-Every failure path is non-fatal; the toolkit falls back to a light popup.
+Every failure path is non-fatal; `with_preferred_app_mode` still runs the closure, so the menu just opens unthemed (light).
 
 | Failure | Reaction |
 |---------|----------|
-| Pre-22000 Windows | The version gate returns `None`, which `OnceLock` caches. Subsequent calls take the cached path with no further probe. |
-| `LoadLibraryExW("uxtheme.dll")` fails | `.inspect_err` emits a single `log::warn!` carrying the underlying `WinError`; `OnceLock` caches `None`. |
-| Ordinal #135 or #136 missing | A single `log::warn!` naming the ordinal; `ux_theme_fns` caches `None` (resolved as a pair). The toolkit falls back to a light popup. |
-| `SetPreferredAppMode` returns a value | Discarded — the return register is read as `i32`, never as a `PreferredAppMode` enum, so an out-of-range value cannot trigger UB. The return is the previous app mode, not a failure code. |
+| Pre-22000 Windows | The version gate returns `None`, cached in `OnceLock`; `set` yields no guard and the closure runs unthemed. |
+| `LoadLibraryExW("uxtheme.dll")` fails | A single `log::warn!` carrying the `WinError`; `OnceLock` caches `None`. |
+| Ordinal #135 or #136 missing | A single `log::warn!` naming the ordinal; `ux_theme_fns` caches `None` (resolved as a pair). |
+| `SetPreferredAppMode` previous mode | Captured as a raw `i32` and fed back verbatim when the guard drops — never rebuilt into a `PreferredAppMode`, so an out-of-range value cannot trigger UB. |
 
 ## 7. Tests
 
@@ -172,10 +191,10 @@ Every failure path is non-fatal; the toolkit falls back to a light popup.
 1. Launch [`SkikoSampleWin32`](../../../../sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt) and ensure the window is dark — automatic when the system theme is dark, otherwise press `D` (step 5).
 2. Right-click the title bar of a `Custom`-title-bar window. The system-menu popup should appear with a dark background, light item text, and visible separators.
 3. Press Alt+Space on the same window. The popup should match step 2.
-4. Call `setImmersiveDarkMode(false)` from Kotlin. The title bar reverts to light; the next menu opens in `ForceLight` mode (light popup) regardless of the Windows system theme.
+4. Call `setImmersiveDarkMode(false)` from Kotlin. The title bar reverts to light, and the window's system menu now opens light regardless of the Windows system theme.
 5. **Re-toggle.** Press the sample's `D` key (in [`SkikoWindowWin32`](../../../../sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt)) to flip dark↔light repeatedly, reopening the system menu after each flip on a window whose menu was already opened once. The popup must recolour on every reopen.
 6. Toggle the Windows system theme. Popups should *not* track the change — `ForceDark` / `ForceLight` overrides the system setting until the next `setImmersiveDarkMode` call.
-7. In a multi-window scenario, set window A to dark and window B to light. Confirm last-call-wins on popup colour: opening the menu on either window paints in the mode last requested.
+7. Multi-window: set window A dark and window B light. Open each window's system menu in both orders — each popup matches its own window, independent of order. After a popup closes, a menu opened by an unrelated control (or the other window) is unaffected, confirming the process mode was restored.
 8. Verify that `SC_*` dispatch still works (existing minimize, maximize, restore, and close behaviour from the system-menu restoration design).
 9. On Windows 10 (any build < 22000), confirm menus stay light, nothing is logged, and the toolkit functions normally.
 
@@ -185,16 +204,12 @@ Every failure path is non-fatal; the toolkit falls back to a light popup.
 
 ## 8. Out of scope
 
-- **Windows 10 (pre-22000) support.** Ordinals #135/#136 work from Windows 10 1903+, but the popup call sits inside `Window::set_immersive_dark_mode`, which early-returns on pre-22000.
+- **Windows 10 (pre-22000) support.** Ordinals #135/#136 work from Windows 10 1903+, but the version gate in `ux_theme_fns` returns early below build 22000, so the menu opens unthemed there.
 - **Per-window `AllowDarkModeForWindow` (ordinal #133).** This ordinal opts an HWND into dark theming for its own child Win32 controls (buttons, scrollbars, edits, listviews). KDT renders via Windows.UI.Composition + Skia and hosts no Win32 child controls, so the call would be a no-op here.
 - **Following the system theme (`AllowDark` + `RefreshImmersiveColorPolicyState`, ordinal #104).** Chromium and ysc3839 set `AllowDark`/`Default` and refresh #104 on `WM_SETTINGCHANGE("ImmersiveColorSet")` to track the system theme. This design forces `ForceDark`/`ForceLight` per `setImmersiveDarkMode` call, so #104 does not apply.
 - **Rounded corners, Mica, reveal animation.** These treatments exist only on XAML `MenuFlyout`, not on native HMENU.
 - **Menu-bar dark theming** (`WM_UAHDRAWMENU` / `WM_UAHDRAWMENUITEM`). The toolkit ships no menu bar.
 - **New Kotlin API.** The design reuses the existing `Window.setImmersiveDarkMode(enabled)`.
-
-## 9. Follow-ups (not in this design)
-
-- **Per-popup scoping for multi-window apps.** Inside `Window::show_system_menu` (called from `WM_NCRBUTTONUP` and the Alt+Space arm), capture the previous app mode, set the window's intended mode via `set_preferred_app_mode`, call `TrackPopupMenu`, and then restore the previous mode. This removes the last-call-wins behaviour at the cost of two extra ordinal calls per popup.
 
 ## References
 

--- a/native/desktop-win32/docs/specs/2026-05-27-win32-dark-system-menu-design.md
+++ b/native/desktop-win32/docs/specs/2026-05-27-win32-dark-system-menu-design.md
@@ -1,0 +1,209 @@
+# Win32 dark-mode system menu — design
+
+**Date**: 2026-05-27
+
+## 1. Purpose
+
+Make the native `HMENU` system-menu popup honour Windows 11's dark theme. The popup opens from `WindowTitleBarKind::Custom` and `WindowTitleBarKind::None` windows via Alt+Space and a right-click on the title bar (see [2026-05-26-win32-system-menu-restoration-design.md](2026-05-26-win32-system-menu-restoration-design.md)). By default it paints with the classic light `COLOR_MENU` palette regardless of the system theme.
+
+To recolour it, drive the OS's immersive dark-mode pipeline through the undocumented `uxtheme.dll` ordinal #135 `SetPreferredAppMode` — the same mechanism Chromium ([`base/win/dark_mode_support.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/win/dark_mode_support.cc)), Edge, Electron, WinAppSDK, and the Windows Settings app rely on. Each `Window.setImmersiveDarkMode(enabled)` call sets `PreferredAppMode::ForceDark` when `enabled`, `ForceLight` otherwise; the next `TrackPopupMenu` paints the popup in that colour.
+
+### What this design is NOT
+
+- No Skia-rendered popup replacement (Chromium's `views::MenuRunner` path).
+- No XAML Islands or WinUI `MenuFlyout`.
+- No HMENU owner-draw.
+
+## 2. Mechanism
+
+Two independent Windows APIs govern the two surfaces (popup and title-bar frame):
+
+| API | Scope | Documented? | Role |
+|-----|-------|-------------|------|
+| `SetPreferredAppMode(Force*)` — `uxtheme.dll` ordinal #135 | Process | No | Sole governor of the `HMENU` popup colour; paired with `FlushMenuThemes` (#136) so already-open menus pick up a change (§3.1). |
+| `DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE, …)` | Per HWND | Yes (Win11 22000+) | Governs the title-bar dark frame only. Called from [`Window::set_immersive_dark_mode`](../../src/win32/window.rs). |
+
+The popup remains a native `HMENU`: same handle, same hit-testing, same accessibility tree, same `TrackPopupMenu` codepath.
+
+### Caveats
+
+- **The ordinals are undocumented.** Microsoft's [undocumented-APIs policy](https://learn.microsoft.com/windows/compatibility/undocumented-apis) warns against ordinal lookups, but #135 and #136 have been stable since Windows 10 1903 across the consumers named in §1. Resolution failure is non-fatal (§6); worst case, the menu stays light.
+- **`SetPreferredAppMode` is process-wide.** Calling `set_immersive_dark_mode` on any window flips the popup mode for every menu opened by the process. A multi-window app with mixed light and dark windows therefore sees last-call-wins on popup colour; every call re-asserts the mode for its window's appearance, so a window can reclaim the popup colour at any time (`set_immersive_dark_mode` does not early-return on an unchanged state). Title-bar frames stay correct per window because the DWM bit is per-HWND. A follow-up in §9 describes how to scope the mode per popup so concurrent windows no longer contend.
+- **`ForceDark` / `ForceLight` ignore the system theme.** The popup colour follows the Kotlin caller, not the user's Windows theme setting.
+- **The popup is not visually Windows 11.** It is a classic flat menu — no Mica, no rounded corners, no reveal animation. Those treatments exist only on XAML `MenuFlyout`, not on native HMENU.
+
+## 3. Module layout
+
+The code lives in [`appearance.rs`](../../src/win32/appearance.rs) alongside the `Appearance` and `HighContrast` types, exposing one `pub(crate)` entry point:
+
+```rust
+pub(crate) fn set_preferred_app_mode(appearance: Appearance);
+```
+
+### 3.1 Internal state
+
+```rust
+type RawProcFn = unsafe extern "system" fn() -> isize;
+// Returns the previous mode as `i32`, not `PreferredAppMode`: an out-of-range enum from FFI would be UB.
+type SetPreferredAppModeFn = unsafe extern "system" fn(PreferredAppMode) -> i32;
+type FlushMenuThemesFn = unsafe extern "system" fn();
+
+#[repr(i32)]
+#[allow(dead_code)]
+enum PreferredAppMode {
+    Default = 0,
+    AllowDark = 1,
+    ForceDark = 2,
+    ForceLight = 3,
+    Max = 4,
+}
+```
+
+Both pointers are resolved once and cached together in a function-scoped `static OnceLock<Option<UxThemeFns>>` (the `UxThemeFns` struct and its loader follow in §3.2). Resolution is all-or-nothing: #135 and #136 shipped together in Windows 10 1903, below our 22000 gate, so they are present as a pair. `SetPreferredAppMode` flips the *process* preferred mode but leaves an already-opened menu — including the cached per-window system-menu `HMENU` — painted in its previous theme. `FlushMenuThemes` (ordinal #136) drops that cached menu theme so the next `TrackPopupMenu` re-themes; it is called immediately after every `SetPreferredAppMode`.
+
+### 3.2 `set_preferred_app_mode`
+
+```rust
+pub(crate) fn set_preferred_app_mode(appearance: Appearance) {
+    let Some(fns) = ux_theme_fns() else {
+        return;
+    };
+    let mode = match appearance {
+        Appearance::Dark => PreferredAppMode::ForceDark,
+        Appearance::Light => PreferredAppMode::ForceLight,
+    };
+    unsafe { (fns.set_preferred_app_mode)(mode) };
+    // SetPreferredAppMode leaves already-themed menus on their old cache; flush so
+    // the next TrackPopupMenu re-themes the system-menu HMENU.
+    unsafe { (fns.flush_menu_themes)() };
+}
+```
+
+The version probe, single DLL load, and per-ordinal resolution sit in `ux_theme_fns`, which caches the pair in one `OnceLock` and returns `None` unless both resolve:
+
+```rust
+struct UxThemeFns {
+    set_preferred_app_mode: SetPreferredAppModeFn,
+    flush_menu_themes: FlushMenuThemesFn,
+}
+
+fn ux_theme_fns() -> Option<&'static UxThemeFns> {
+    static FNS: OnceLock<Option<UxThemeFns>> = OnceLock::new();
+    FNS.get_or_init(|| {
+        if !utils::is_windows_11_build_22000_or_higher() {
+            return None;
+        }
+        let module = match unsafe { LoadLibraryExW(w!("uxtheme.dll"), None, LOAD_LIBRARY_SEARCH_SYSTEM32) } {
+            Ok(module) => module,
+            Err(err) => {
+                log::warn!("LoadLibraryExW(uxtheme.dll) failed: {err}");
+                return None;
+            }
+        };
+        let set_preferred_app_mode = resolve_ordinal(module, 135, "SetPreferredAppMode")?;
+        let flush_menu_themes = resolve_ordinal(module, 136, "FlushMenuThemes")?;
+        Some(UxThemeFns {
+            // SAFETY: ordinal #135 signature per Chromium base/win/dark_mode_support.cc
+            // and ysc3839/win32-darkmode. Both stub and target are `extern "system"`.
+            set_preferred_app_mode: unsafe { std::mem::transmute::<RawProcFn, SetPreferredAppModeFn>(set_preferred_app_mode) },
+            // SAFETY: ordinal #136 signature per ysc3839/win32-darkmode (`void()`).
+            flush_menu_themes: unsafe { std::mem::transmute::<RawProcFn, FlushMenuThemesFn>(flush_menu_themes) },
+        })
+    })
+    .as_ref()
+}
+
+fn resolve_ordinal(module: HMODULE, n: u16, name: &str) -> Option<RawProcFn> {
+    // MAKEINTRESOURCEA: the ordinal sits in the low word of an otherwise-null PCSTR.
+    let ordinal = PCSTR(n as usize as *const u8);
+    let raw = unsafe { GetProcAddress(module, ordinal) };
+    if raw.is_none() {
+        log::warn!("uxtheme ordinal #{n} ({name}) missing");
+    }
+    raw
+}
+```
+
+`LOAD_LIBRARY_SEARCH_SYSTEM32` blocks the loader from resolving `uxtheme.dll` from a planted copy on the application's search path. The `ordinal` cast is the `MAKEINTRESOURCEA` form `GetProcAddress` expects — the value in the low word, no string.
+
+## 4. Wire-up — [`window.rs`](../../src/win32/window.rs)
+
+`Window::set_immersive_dark_mode` toggles `DWMWA_USE_IMMERSIVE_DARK_MODE`, derives an `Appearance` from the new state, and propagates it to the caption-button strip. The popup-mode call joins that pipeline at the same point:
+
+```rust
+pub fn set_immersive_dark_mode(&self, enabled: bool) -> WinResult<()> {
+    // …existing DWM toggle…
+    let appearance = if enabled { Appearance::Dark } else { Appearance::Light };
+    self.with_strip_mut(|strip| strip.on_appearance_change(appearance));
+    appearance::set_preferred_app_mode(appearance);
+    self.immersive_dark.set(enabled); // commit state after the side effects land
+    Ok(())
+}
+```
+
+The process-wide mode flip happens whenever a Kotlin caller sets immersive dark/light on a window — `set_immersive_dark_mode` no longer early-returns on an unchanged state, so a window always re-asserts its popup colour (the caption strip still skips repainting when the appearance is unchanged).
+
+## 5. Cargo.toml
+
+No new dependencies. The imports come from the `windows` features already enabled in [Cargo.toml](../../Cargo.toml), in particular `Win32_System_LibraryLoader`. The code uses:
+
+- `std::sync::OnceLock`, `std::mem::transmute`, and the workspace `log` macros.
+- `windows::Win32::System::LibraryLoader::{LoadLibraryExW, GetProcAddress, LOAD_LIBRARY_SEARCH_SYSTEM32}` for the ordinal lookup, plus `windows::Win32::Foundation::HMODULE` for the resolved-module handle.
+- `windows_core::{PCSTR, w}` for the wide-string DLL name (`w!`) and the `MAKEINTRESOURCEA` ordinal cast (`PCSTR`) in `resolve_ordinal`.
+- `super::utils::is_windows_11_build_22000_or_higher` for the version gate.
+
+## 6. Error handling
+
+Every failure path is non-fatal; the toolkit falls back to a light popup.
+
+| Failure | Reaction |
+|---------|----------|
+| Pre-22000 Windows | The version gate returns `None`, which `OnceLock` caches. Subsequent calls take the cached path with no further probe. |
+| `LoadLibraryExW("uxtheme.dll")` fails | `.inspect_err` emits a single `log::warn!` carrying the underlying `WinError`; `OnceLock` caches `None`. |
+| Ordinal #135 or #136 missing | A single `log::warn!` naming the ordinal; `ux_theme_fns` caches `None` (resolved as a pair). The toolkit falls back to a light popup. |
+| `SetPreferredAppMode` returns a value | Discarded — the return register is read as `i32`, never as a `PreferredAppMode` enum, so an out-of-range value cannot trigger UB. The return is the previous app mode, not a failure code. |
+
+## 7. Tests
+
+**Unit tests are not viable** — ordinal resolution and uxtheme behaviour can only be exercised against a live Windows 11 22000+ system.
+
+**Manual verification** (sample app). Steps 1–8 run on Windows 11 22000+; step 9 is the pre-22000 fallback check.
+
+1. Launch [`SkikoSampleWin32`](../../../../sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt) and ensure the window is dark — automatic when the system theme is dark, otherwise press `D` (step 5).
+2. Right-click the title bar of a `Custom`-title-bar window. The system-menu popup should appear with a dark background, light item text, and visible separators.
+3. Press Alt+Space on the same window. The popup should match step 2.
+4. Call `setImmersiveDarkMode(false)` from Kotlin. The title bar reverts to light; the next menu opens in `ForceLight` mode (light popup) regardless of the Windows system theme.
+5. **Re-toggle.** Press the sample's `D` key (in [`SkikoWindowWin32`](../../../../sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt)) to flip dark↔light repeatedly, reopening the system menu after each flip on a window whose menu was already opened once. The popup must recolour on every reopen.
+6. Toggle the Windows system theme. Popups should *not* track the change — `ForceDark` / `ForceLight` overrides the system setting until the next `setImmersiveDarkMode` call.
+7. In a multi-window scenario, set window A to dark and window B to light. Confirm last-call-wins on popup colour: opening the menu on either window paints in the mode last requested.
+8. Verify that `SC_*` dispatch still works (existing minimize, maximize, restore, and close behaviour from the system-menu restoration design).
+9. On Windows 10 (any build < 22000), confirm menus stay light, nothing is logged, and the toolkit functions normally.
+
+**Regression.** The existing `system_menu_enable_table` decision-table tests stay green.
+
+**Lint.** `./gradlew lint` must pass per [CLAUDE.md](../../../../CLAUDE.md).
+
+## 8. Out of scope
+
+- **Windows 10 (pre-22000) support.** Ordinals #135/#136 work from Windows 10 1903+, but the popup call sits inside `Window::set_immersive_dark_mode`, which early-returns on pre-22000.
+- **Per-window `AllowDarkModeForWindow` (ordinal #133).** This ordinal opts an HWND into dark theming for its own child Win32 controls (buttons, scrollbars, edits, listviews). KDT renders via Windows.UI.Composition + Skia and hosts no Win32 child controls, so the call would be a no-op here.
+- **Following the system theme (`AllowDark` + `RefreshImmersiveColorPolicyState`, ordinal #104).** Chromium and ysc3839 set `AllowDark`/`Default` and refresh #104 on `WM_SETTINGCHANGE("ImmersiveColorSet")` to track the system theme. This design forces `ForceDark`/`ForceLight` per `setImmersiveDarkMode` call, so #104 does not apply.
+- **Rounded corners, Mica, reveal animation.** These treatments exist only on XAML `MenuFlyout`, not on native HMENU.
+- **Menu-bar dark theming** (`WM_UAHDRAWMENU` / `WM_UAHDRAWMENUITEM`). The toolkit ships no menu bar.
+- **New Kotlin API.** The design reuses the existing `Window.setImmersiveDarkMode(enabled)`.
+
+## 9. Follow-ups (not in this design)
+
+- **Per-popup scoping for multi-window apps.** Inside `Window::show_system_menu` (called from `WM_NCRBUTTONUP` and the Alt+Space arm), capture the previous app mode, set the window's intended mode via `set_preferred_app_mode`, call `TrackPopupMenu`, and then restore the previous mode. This removes the last-call-wins behaviour at the cost of two extra ordinal calls per popup.
+
+## References
+
+- [SetWindowAttribute / DWMWA_USE_IMMERSIVE_DARK_MODE](https://learn.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute)
+- [Apply Windows themes (Win32 dark mode scope)](https://learn.microsoft.com/windows/apps/desktop/modernize/ui/apply-windows-themes)
+- [Undocumented APIs policy](https://learn.microsoft.com/windows/compatibility/undocumented-apis)
+- [LoadLibraryExW + LOAD_LIBRARY_SEARCH_SYSTEM32](https://learn.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw)
+- [Chromium `base/win/dark_mode_support.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/win/dark_mode_support.cc) — reference implementation of ordinals 133 / 135.
+- [WinAppSDK Discussion #2967 — titlebar context menu dark theme](https://github.com/microsoft/WindowsAppSDK/discussions/2967) — same ordinal usage in WinUI / WinAppSDK.
+- [ysc3839/win32-darkmode](https://github.com/ysc3839/win32-darkmode) — canonical reference for the undocumented uxtheme dark-mode ordinals.
+- [2026-05-26-win32-system-menu-restoration-design.md](2026-05-26-win32-system-menu-restoration-design.md) — system-menu plumbing this design extends.
+- [2026-04-30-win32-caption-buttons-design.md](2026-04-30-win32-caption-buttons-design.md) — caption-button strip context.

--- a/native/desktop-win32/src/win32/appearance.rs
+++ b/native/desktop-win32/src/win32/appearance.rs
@@ -1,15 +1,23 @@
+use std::sync::OnceLock;
+
 use desktop_common::logger::PanicDefault;
 use windows::{
     UI::{
         Color as WUColor,
         ViewManagement::{UIColorType, UISettings},
     },
-    Win32::UI::{
-        Accessibility::{HCF_HIGHCONTRASTON, HIGHCONTRASTW, HIGHCONTRASTW_FLAGS},
-        WindowsAndMessaging::{SPI_GETHIGHCONTRAST, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW},
+    Win32::{
+        Foundation::HMODULE,
+        System::LibraryLoader::{GetProcAddress, LOAD_LIBRARY_SEARCH_SYSTEM32, LoadLibraryExW},
+        UI::{
+            Accessibility::{HCF_HIGHCONTRASTON, HIGHCONTRASTW, HIGHCONTRASTW_FLAGS},
+            WindowsAndMessaging::{SPI_GETHIGHCONTRAST, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW},
+        },
     },
 };
-use windows_core::{PWSTR, Result as WinResult};
+use windows_core::{PCSTR, PWSTR, Result as WinResult, w};
+
+use super::utils;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,4 +102,78 @@ impl HighContrast {
 #[inline]
 const fn is_color_light(clr: WUColor) -> bool {
     ((5 * clr.G as u32) + (2 * clr.R as u32) + clr.B as u32) > (8 * 128)
+}
+
+type RawProcFn = unsafe extern "system" fn() -> isize;
+// Returns the previous mode as `i32`, not `PreferredAppMode`: an out-of-range enum from FFI would be UB.
+type SetPreferredAppModeFn = unsafe extern "system" fn(PreferredAppMode) -> i32;
+type FlushMenuThemesFn = unsafe extern "system" fn();
+
+#[repr(i32)]
+#[allow(dead_code)]
+enum PreferredAppMode {
+    Default = 0,
+    AllowDark = 1,
+    ForceDark = 2,
+    ForceLight = 3,
+    Max = 4,
+}
+
+/// `uxtheme.dll` dark-mode ordinals #135 and #136, resolved as a pair (both shipped
+/// in Windows 10 1903, below our 22000 gate).
+struct UxThemeFns {
+    set_preferred_app_mode: SetPreferredAppModeFn,
+    flush_menu_themes: FlushMenuThemesFn,
+}
+
+/// Resolve and cache the ordinals once. `None` (logged, non-fatal) on pre-22000
+/// Windows, DLL-load failure, or either ordinal missing — the popup then stays light.
+fn ux_theme_fns() -> Option<&'static UxThemeFns> {
+    static FNS: OnceLock<Option<UxThemeFns>> = OnceLock::new();
+    FNS.get_or_init(|| {
+        if !utils::is_windows_11_build_22000_or_higher() {
+            return None;
+        }
+        let module = match unsafe { LoadLibraryExW(w!("uxtheme.dll"), None, LOAD_LIBRARY_SEARCH_SYSTEM32) } {
+            Ok(module) => module,
+            Err(err) => {
+                log::warn!("LoadLibraryExW(uxtheme.dll) failed: {err}");
+                return None;
+            }
+        };
+        let set_preferred_app_mode = resolve_ordinal(module, 135, "SetPreferredAppMode")?;
+        let flush_menu_themes = resolve_ordinal(module, 136, "FlushMenuThemes")?;
+        Some(UxThemeFns {
+            // SAFETY: ordinal #135 signature per Chromium base/win/dark_mode_support.cc
+            // and ysc3839/win32-darkmode. Both stub and target are `extern "system"`.
+            set_preferred_app_mode: unsafe { std::mem::transmute::<RawProcFn, SetPreferredAppModeFn>(set_preferred_app_mode) },
+            // SAFETY: ordinal #136 signature per ysc3839/win32-darkmode (`void()`).
+            flush_menu_themes: unsafe { std::mem::transmute::<RawProcFn, FlushMenuThemesFn>(flush_menu_themes) },
+        })
+    })
+    .as_ref()
+}
+
+fn resolve_ordinal(module: HMODULE, n: u16, name: &str) -> Option<RawProcFn> {
+    // MAKEINTRESOURCEA: the ordinal sits in the low word of an otherwise-null PCSTR.
+    let ordinal = PCSTR(n as usize as *const u8);
+    let raw = unsafe { GetProcAddress(module, ordinal) };
+    if raw.is_none() {
+        log::warn!("uxtheme ordinal #{n} ({name}) missing");
+    }
+    raw
+}
+
+pub(crate) fn set_preferred_app_mode(appearance: Appearance) {
+    let Some(fns) = ux_theme_fns() else {
+        return;
+    };
+    let mode = match appearance {
+        Appearance::Dark => PreferredAppMode::ForceDark,
+        Appearance::Light => PreferredAppMode::ForceLight,
+    };
+    unsafe { (fns.set_preferred_app_mode)(mode) };
+    // SetPreferredAppMode leaves already-themed menus on their old cache; flush so
+    // the next TrackPopupMenu re-themes the system-menu HMENU.
+    unsafe { (fns.flush_menu_themes)() };
 }

--- a/native/desktop-win32/src/win32/appearance.rs
+++ b/native/desktop-win32/src/win32/appearance.rs
@@ -105,8 +105,9 @@ const fn is_color_light(clr: WUColor) -> bool {
 }
 
 type RawProcFn = unsafe extern "system" fn() -> isize;
-// Returns the previous mode as `i32`, not `PreferredAppMode`: an out-of-range enum from FFI would be UB.
-type SetPreferredAppModeFn = unsafe extern "system" fn(PreferredAppMode) -> i32;
+// Raw `i32` both ways: pass `PreferredAppMode as i32` going in, feed the returned previous
+// mode straight back when restoring, without rebuilding a `#[repr(i32)]` enum from it.
+type SetPreferredAppModeFn = unsafe extern "system" fn(i32) -> i32;
 type FlushMenuThemesFn = unsafe extern "system" fn();
 
 #[repr(i32)]
@@ -164,16 +165,37 @@ fn resolve_ordinal(module: HMODULE, n: u16, name: &str) -> Option<RawProcFn> {
     raw
 }
 
-pub(crate) fn set_preferred_app_mode(appearance: Appearance) {
-    let Some(fns) = ux_theme_fns() else {
-        return;
-    };
-    let mode = match appearance {
-        Appearance::Dark => PreferredAppMode::ForceDark,
-        Appearance::Light => PreferredAppMode::ForceLight,
-    };
-    unsafe { (fns.set_preferred_app_mode)(mode) };
-    // SetPreferredAppMode leaves already-themed menus on their old cache; flush so
-    // the next TrackPopupMenu re-themes the system-menu HMENU.
-    unsafe { (fns.flush_menu_themes)() };
+/// Forces the menu palette, flushes cached menu themes, and captures the previous
+/// process mode; the previous mode is restored (and flushed again) on drop.
+struct PreferredAppModeGuard {
+    fns: &'static UxThemeFns,
+    previous: i32,
+}
+
+impl PreferredAppModeGuard {
+    fn set(appearance: Appearance) -> Option<Self> {
+        let fns = ux_theme_fns()?;
+        let mode = match appearance {
+            Appearance::Dark => PreferredAppMode::ForceDark,
+            Appearance::Light => PreferredAppMode::ForceLight,
+        };
+        let previous = unsafe { (fns.set_preferred_app_mode)(mode as i32) };
+        unsafe { (fns.flush_menu_themes)() };
+        Some(Self { fns, previous })
+    }
+}
+
+impl Drop for PreferredAppModeGuard {
+    fn drop(&mut self) {
+        unsafe { (self.fns.set_preferred_app_mode)(self.previous) };
+        unsafe { (self.fns.flush_menu_themes)() };
+    }
+}
+
+/// Runs `f` with the menu palette forced to `appearance`, restoring the previous
+/// process mode afterward. On pre-22000 Windows (or resolution failure) the mode is
+/// left untouched and `f` still runs, so the menu opens unthemed.
+pub(crate) fn with_preferred_app_mode<R>(appearance: Appearance, f: impl FnOnce() -> R) -> R {
+    let _guard = PreferredAppModeGuard::set(appearance);
+    f()
 }

--- a/native/desktop-win32/src/win32/caption_buttons.rs
+++ b/native/desktop-win32/src/win32/caption_buttons.rs
@@ -177,6 +177,7 @@ fn resolve_interaction(
     }
 }
 
+#[derive(Clone, Copy)]
 struct CaptionTheme {
     backplate_rest: windows::UI::Color,
     backplate_hover: windows::UI::Color,
@@ -310,7 +311,7 @@ impl StripGeometry {
         if y < 0 || y >= bh {
             return None;
         }
-        let count = self.visible_kinds.0.count_ones() as i32;
+        let count = self.visible_kinds.iter_ordered().count() as i32;
         let strip_left = self.reference_width_px - bw * count;
         for (i, kind) in self.visible_kinds.iter_ordered().enumerate() {
             let x_left = strip_left + (i as i32) * bw;
@@ -369,10 +370,10 @@ pub(crate) fn caption_kind_at_screen(window: &Window, screen: PhysicalPoint) -> 
         x: screen.x.0,
         y: screen.y.0,
     };
-    unsafe { ScreenToClient(hwnd, &raw mut client_point) }
-        .ok()
-        .inspect_err(|err| log::warn!("ScreenToClient failed: {err}"))
-        .ok()?;
+    if let Err(err) = unsafe { ScreenToClient(hwnd, &raw mut client_point) }.ok() {
+        log::warn!("ScreenToClient failed: {err}");
+        return None;
+    }
     let mut client_rect = RECT::default();
     unsafe { GetClientRect(hwnd, &raw mut client_rect) }
         .inspect_err(|err| log::warn!("GetClientRect failed: {err}"))
@@ -400,8 +401,7 @@ fn is_in_top_resize_border(window: &Window, mouse_y: i32) -> bool {
     {
         return false;
     }
-    let m = window.dpi_metrics();
-    mouse_y < window_rect.top + m.padded_border + m.size_frame
+    mouse_y < window_rect.top + window.dpi_metrics().resize_handle_height()
 }
 
 pub(crate) struct CaptionButtonStrip {
@@ -412,6 +412,7 @@ pub(crate) struct CaptionButtonStrip {
     is_window_maximized: bool,
     appearance: Appearance,
     high_contrast: HighContrast,
+    theme: CaptionTheme,
     metrics: CaptionButtonMetrics,
     pointer_over_kind: Option<CaptionButtonKind>,
     pointer_device: Option<PointerDeviceKind>,
@@ -507,6 +508,7 @@ impl CaptionButtonStrip {
             is_window_maximized: initial_is_maximized,
             appearance: initial_appearance,
             high_contrast,
+            theme: CaptionTheme::resolve(initial_appearance, high_contrast),
             metrics,
             pointer_over_kind: None,
             pointer_device: None,
@@ -580,7 +582,7 @@ impl CaptionButtonStrip {
     fn apply_visuals_to_all_buttons(&mut self) {
         self.rasterise_all_glyphs();
 
-        let theme = CaptionTheme::resolve(self.appearance, self.high_contrast);
+        let theme = self.theme;
         let pointer_over_kind = self.pointer_over_kind;
         let pointer_device = self.pointer_device;
         let primary_press = self.primary_press;
@@ -804,17 +806,20 @@ impl CaptionButtonStrip {
             return;
         }
         self.appearance = appearance;
+        self.theme = CaptionTheme::resolve(appearance, self.high_contrast);
         self.apply_visuals_to_all_buttons();
     }
 
-    /// Dirties every glyph surface: HC swaps glyph code points / fill style alongside the palette.
+    /// Re-resolves the cached palette; re-rasterises glyph surfaces only on an actual HC on/off toggle.
     pub fn on_high_contrast_change(&mut self, hc: HighContrast) {
-        if self.high_contrast == hc {
-            return;
-        }
+        let hc_toggled = self.high_contrast != hc;
         self.high_contrast = hc;
-        for button in &mut self.buttons {
-            button.glyph_surface_dirty = true;
+        // WM_SYSCOLORCHANGE can change HC colours without toggling the on/off state.
+        self.theme = CaptionTheme::resolve(self.appearance, hc);
+        if hc_toggled {
+            for button in &mut self.buttons {
+                button.glyph_surface_dirty = true;
+            }
         }
         self.apply_visuals_to_all_buttons();
     }

--- a/native/desktop-win32/src/win32/caption_buttons.rs
+++ b/native/desktop-win32/src/win32/caption_buttons.rs
@@ -810,11 +810,15 @@ impl CaptionButtonStrip {
         self.apply_visuals_to_all_buttons();
     }
 
-    /// Re-resolves the cached palette; re-rasterises glyph surfaces only on an actual HC on/off toggle.
+    /// Refreshes the cached palette and repaints, re-rasterising glyphs only on an on/off toggle.
+    /// The high-contrast palette can change while it stays on, so it refreshes whenever HC is on
+    /// and skips an unchanged off state (its palette is fixed).
     pub fn on_high_contrast_change(&mut self, hc: HighContrast) {
         let hc_toggled = self.high_contrast != hc;
+        if !hc_toggled && hc == HighContrast::Off {
+            return;
+        }
         self.high_contrast = hc;
-        // WM_SYSCOLORCHANGE can change HC colours without toggling the on/off state.
         self.theme = CaptionTheme::resolve(self.appearance, hc);
         if hc_toggled {
             for button in &mut self.buttons {

--- a/native/desktop-win32/src/win32/event_loop.rs
+++ b/native/desktop-win32/src/win32/event_loop.rs
@@ -532,31 +532,26 @@ fn on_nchittest(event_loop: &EventLoop, window: &Window, wparam: WPARAM, lparam:
     }
 
     let event = NCHitTestEvent { mouse_x, mouse_y };
-    let handled = event_loop.handle_event(window, event);
-    if handled.is_some() {
+    if event_loop.handle_event(window, event).is_some() {
         return Some(LRESULT(HTCLIENT as _));
     }
     let mut window_rect = RECT::default();
     let _ = unsafe { GetWindowRect(hwnd, &raw mut window_rect) };
     let m = window.dpi_metrics();
-    let resize_handle_height = m.padded_border + m.size_frame;
-    let title_bar_height = resize_handle_height + unsafe { GetSystemMetricsForDpi(SM_CYSIZE, m.dpi) };
-    // Only the resize-border match is gated on `is_resizable`; the title-bar
-    // drag region applies to non-resizable custom-titlebar windows too so they
-    // remain draggable by their title bar.
-    //
-    // `WindowTitleBarKind::None` must not expose a synthetic drag band.
-    let allow_titlebar_drag = window.has_custom_title_bar();
-    let is_on_resize_border = window.is_resizable() && mouse_y < (window_rect.top + resize_handle_height) as _;
-    let is_within_title_bar = mouse_y < (window_rect.top + title_bar_height) as _;
-    let hit_test_result = if is_on_resize_border {
-        HTTOP
-    } else if allow_titlebar_drag && is_within_title_bar {
-        HTCAPTION
-    } else {
-        HTCLIENT
-    };
-    Some(LRESULT(hit_test_result as _))
+    let top = window_rect.top;
+    let resize_band = m.resize_handle_height();
+    // Resize border is gated on `is_resizable`; the title-bar drag region applies to
+    // non-resizable custom titlebars too. `WindowTitleBarKind::None` gets no drag band.
+    if window.is_resizable() && mouse_y < (top + resize_band) as _ {
+        return Some(LRESULT(HTTOP as _));
+    }
+    if window.has_custom_title_bar() {
+        let title_bar_height = resize_band + unsafe { GetSystemMetricsForDpi(SM_CYSIZE, m.dpi) };
+        if mouse_y < (top + title_bar_height) as _ {
+            return Some(LRESULT(HTCAPTION as _));
+        }
+    }
+    Some(LRESULT(HTCLIENT as _))
 }
 
 fn on_ncmouseleave(window: &Window, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -102,6 +102,12 @@ impl DpiMetrics {
             size_frame: unsafe { GetSystemMetricsForDpi(SM_CYSIZEFRAME, dpi) },
         }
     }
+
+    /// Height of the top resize-handle band: `SM_CXPADDEDBORDER + SM_CYSIZEFRAME`.
+    /// There is no `SM_CYPADDEDBORDER`; the X padded-border value is used on both axes.
+    pub(crate) const fn resize_handle_height(self) -> i32 {
+        self.padded_border + self.size_frame
+    }
 }
 
 #[allow(clippy::struct_field_names)]

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -41,7 +41,7 @@ use windows::{
 use windows_core::{HSTRING, Interface, PCWSTR, Result as WinResult, w};
 
 use super::{
-    appearance::Appearance,
+    appearance::{self, Appearance},
     caption_buttons::CaptionButtonStrip,
     cursor::{Cursor, CursorIcon},
     event_loop::EventLoop,
@@ -525,9 +525,6 @@ impl Window {
         if !utils::is_windows_11_build_22000_or_higher() {
             return Ok(());
         }
-        if self.immersive_dark.get() == enabled {
-            return Ok(());
-        }
         let enablement = windows_core::BOOL::from(enabled);
         unsafe {
             DwmSetWindowAttribute(
@@ -537,9 +534,10 @@ impl Window {
                 size_of::<windows_core::BOOL>().try_into()?,
             )?;
         }
-        self.immersive_dark.set(enabled);
         let appearance = if enabled { Appearance::Dark } else { Appearance::Light };
         self.with_strip_mut(|strip| strip.on_appearance_change(appearance));
+        appearance::set_preferred_app_mode(appearance);
+        self.immersive_dark.set(enabled);
         Ok(())
     }
 

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -418,21 +418,30 @@ impl Window {
         }
 
         let _ = unsafe { SetForegroundWindow(hwnd) };
-        // TrackPopupMenu with TPM_RETURNCMD returns 0 for both cancel and
-        // failure; distinguish via GetLastError.
-        unsafe { SetLastError(WIN32_ERROR(0)) };
-        let cmd = unsafe {
-            TrackPopupMenu(
-                h_menu,
-                TPM_RIGHTBUTTON | TPM_RETURNCMD,
-                screen_pt.x.0,
-                screen_pt.y.0,
-                None,
-                hwnd,
-                None,
-            )
+        // Theme the popup from this window's own state; the mode is process-global,
+        // so force it only around TrackPopupMenu and restore it afterward.
+        let appearance = if self.immersive_dark.get() {
+            Appearance::Dark
+        } else {
+            Appearance::Light
         };
-        let last_error = unsafe { GetLastError() };
+        // TrackPopupMenu with TPM_RETURNCMD returns 0 for both cancel and
+        // failure; distinguish via GetLastError (read inside the closure, before restore).
+        let (cmd, last_error) = appearance::with_preferred_app_mode(appearance, || {
+            unsafe { SetLastError(WIN32_ERROR(0)) };
+            let cmd = unsafe {
+                TrackPopupMenu(
+                    h_menu,
+                    TPM_RIGHTBUTTON | TPM_RETURNCMD,
+                    screen_pt.x.0,
+                    screen_pt.y.0,
+                    None,
+                    hwnd,
+                    None,
+                )
+            };
+            (cmd, unsafe { GetLastError() })
+        });
         // Docs-recommended post-show null-message flush.
         let _ = unsafe { PostMessageW(Some(hwnd), WM_NULL, WPARAM(0), LPARAM(0)) };
 
@@ -525,6 +534,9 @@ impl Window {
         if !utils::is_windows_11_build_22000_or_higher() {
             return Ok(());
         }
+        if self.immersive_dark.get() == enabled {
+            return Ok(());
+        }
         let enablement = windows_core::BOOL::from(enabled);
         unsafe {
             DwmSetWindowAttribute(
@@ -536,7 +548,6 @@ impl Window {
         }
         let appearance = if enabled { Appearance::Dark } else { Appearance::Light };
         self.with_strip_mut(|strip| strip.on_appearance_change(appearance));
-        appearance::set_preferred_app_mode(appearance);
         self.immersive_dark.set(enabled);
         Ok(())
     }

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
@@ -103,7 +103,7 @@ class ApplicationState(private val app: Application) : AutoCloseable {
         val appearance = Appearance.getCurrent()
         Logger.debug { "Current appearance: $appearance" }
         if (appearance == Appearance.Dark) {
-            window.window.setImmersiveDarkMode(true)
+            window.setImmersiveDarkMode(true)
         }
 
         window.initializeDropManager()

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt
@@ -57,6 +57,13 @@ abstract class SkikoWindowWin32(app: Application) : AutoCloseable {
 
     private var dragDropManager: DragDropManager? = null
 
+    private var immersiveDark = false
+
+    fun setImmersiveDarkMode(enabled: Boolean) {
+        immersiveDark = enabled
+        window.setImmersiveDarkMode(enabled)
+    }
+
     private fun isSizeChanged(size: PhysicalSize): Boolean {
         return (size.width != currentSize.width || size.height != currentSize.height)
     }
@@ -142,6 +149,11 @@ abstract class SkikoWindowWin32(app: Application) : AutoCloseable {
                         window.removeBackdropTint()
                     }
 
+                    VirtualKey.D -> {
+                        setImmersiveDarkMode(!immersiveDark)
+                        Logger.debug { "Immersive dark mode: $immersiveDark" }
+                    }
+
                     VirtualKey.C -> {
                         if (Keyboard.getKeyState(VirtualKey.Control).isDown) {
                             DataObject.build {
@@ -203,8 +215,7 @@ abstract class SkikoWindowWin32(app: Application) : AutoCloseable {
 
             is Event.SystemAppearanceChange -> with(event) {
                 Logger.debug { "Setting change: new appearance: $newAppearance" }
-                val enableImmersiveDarkMode = newAppearance == Appearance.Dark
-                window.setImmersiveDarkMode(enableImmersiveDarkMode)
+                setImmersiveDarkMode(newAppearance == Appearance.Dark)
                 EventHandlerResult.Stop
             }
 


### PR DESCRIPTION
The native HMENU system menu (Alt+Space or title-bar right-click) painted light
regardless of theme. Each window's system menu now follows that window's
dark/light state: opening it forces uxtheme's undocumented `SetPreferredAppMode`
(#135) and flushes cached menu themes (#136) for the duration of the popup, then
restores the prior process mode — so mixed-theme multi-window apps stay correct.

Rationale and caveats are in the design doc under `native/desktop-win32/docs/specs/`.

## Verification
Manual on Windows 11 22000+ (dark popup via right-click / Alt+Space; recolours on
the sample's D-key toggle; two-window mixed-theme check); `./gradlew lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
