### PR TITLE
feat(win32): add Window.forceFocus to bring window to foreground

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Window.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/Window.kt
@@ -234,6 +234,18 @@ public class Window internal constructor(
         return ffiDownCall { desktop_win32_h.window_show(ptr) }
     }
 
+    /**
+     * Forcibly brings the window to the foreground and gives it keyboard focus,
+     * stealing focus from whatever the user is currently interacting with.
+     *
+     * This works around Windows' foreground-activation lock, which otherwise prevents
+     * a process that doesn't own the foreground (e.g. an app launched from a terminal
+     * or IDE) from activating its window. Use sparingly, as stealing focus is intrusive.
+     */
+    public fun forceFocus() {
+        return ffiDownCall { desktop_win32_h.window_force_focus(ptr) }
+    }
+
     public fun requestRedraw() {
         ffiDownCall { desktop_win32_h.window_request_redraw(ptr) }
     }

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -452,7 +452,7 @@ impl Window {
         // `ShowWindow(SW_RESTORE)`: it is synchronous on the window's UI thread (ShowWindow
         // is async when issued cross-thread) and preserves the standard restore animation.
         if self.is_minimized() {
-            self.send_system_command(SC_RESTORE);
+            self.restore();
         }
 
         unsafe {

--- a/native/desktop-win32/src/win32/window.rs
+++ b/native/desktop-win32/src/win32/window.rs
@@ -20,19 +20,23 @@ use windows::{
             },
             Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromWindow, RDW_INVALIDATE, RDW_NOERASE, RDW_NOFRAME, RedrawWindow},
         },
-        System::WinRT::Composition::ICompositorDesktopInterop,
+        System::{
+            Threading::{AttachThreadInput, GetCurrentThreadId},
+            WinRT::Composition::ICompositorDesktopInterop,
+        },
         UI::{
             Controls::MARGINS,
             HiDpi::{GetDpiForWindow, GetSystemMetricsForDpi},
+            Input::KeyboardAndMouse::SetActiveWindow,
             WindowsAndMessaging::{
-                CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, CreateIconFromResourceEx, CreateWindowExW, DefWindowProcW, DestroyWindow, GWL_STYLE,
-                GetClientRect, GetPropW, GetWindowLongPtrW, HMENU, ICON_BIG, ICON_SMALL, IsIconic, IsZoomed, LR_DEFAULTCOLOR, PostMessageW,
-                RegisterClassExW, RemovePropW, SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SM_CXICON, SM_CXPADDEDBORDER, SM_CXSMICON, SM_CYICON,
-                SM_CYSIZEFRAME, SM_CYSMICON, SW_SHOW, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOOWNERZORDER, SWP_NOSIZE,
-                SWP_NOZORDER, SendMessageW, SetCursor, SetForegroundWindow, SetPropW, SetWindowLongPtrW, SetWindowPos, SetWindowTextW,
-                ShowWindow, TPM_RETURNCMD, TPM_RIGHTBUTTON, TrackPopupMenu, USER_DEFAULT_SCREEN_DPI, WM_CLOSE, WM_NCCREATE, WM_NCDESTROY,
-                WM_NULL, WM_SETICON, WM_SYSCOMMAND, WNDCLASSEXW, WS_EX_NOREDIRECTIONBITMAP, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
-                WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
+                BringWindowToTop, CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, CreateIconFromResourceEx, CreateWindowExW, DefWindowProcW,
+                DestroyWindow, GWL_STYLE, GetClientRect, GetForegroundWindow, GetPropW, GetWindowLongPtrW, GetWindowThreadProcessId, HMENU,
+                ICON_BIG, ICON_SMALL, IsHungAppWindow, IsIconic, IsZoomed, LR_DEFAULTCOLOR, PostMessageW, RegisterClassExW, RemovePropW,
+                SC_MAXIMIZE, SC_MINIMIZE, SC_RESTORE, SM_CXICON, SM_CXPADDEDBORDER, SM_CXSMICON, SM_CYICON, SM_CYSIZEFRAME, SM_CYSMICON,
+                SW_SHOW, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOOWNERZORDER, SWP_NOSIZE, SWP_NOZORDER, SendMessageW,
+                SetCursor, SetForegroundWindow, SetPropW, SetWindowLongPtrW, SetWindowPos, SetWindowTextW, ShowWindow, TPM_RETURNCMD,
+                TPM_RIGHTBUTTON, TrackPopupMenu, USER_DEFAULT_SCREEN_DPI, WM_CLOSE, WM_NCCREATE, WM_NCDESTROY, WM_NULL, WM_SETICON,
+                WM_SYSCOMMAND, WNDCLASSEXW, WS_EX_NOREDIRECTIONBITMAP, WS_MAXIMIZEBOX, WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
             },
         },
     },
@@ -430,6 +434,51 @@ impl Window {
 
     pub fn show(&self) {
         let _ = unsafe { ShowWindow(self.hwnd(), SW_SHOW) };
+    }
+
+    /// Forcibly brings the window to the foreground and gives it keyboard focus.
+    ///
+    /// Windows refuses `SetForegroundWindow` for a process that does not own the
+    /// current foreground window (e.g. when the app is launched from a terminal or
+    /// IDE rather than the shell), and merely flashes the taskbar button instead.
+    /// Temporarily attaching our input queue to the foreground window's thread lifts
+    /// that restriction for the duration of the call. This deliberately steals focus
+    /// from whatever the user is doing, so it should be used sparingly.
+    pub fn force_focus(&self) {
+        let hwnd = self.hwnd();
+
+        // Restore first if minimized, otherwise the window would be activated but stay
+        // iconic. Route through WM_SYSCOMMAND (SC_RESTORE) like `restore()` rather than
+        // `ShowWindow(SW_RESTORE)`: it is synchronous on the window's UI thread (ShowWindow
+        // is async when issued cross-thread) and preserves the standard restore animation.
+        if self.is_minimized() {
+            self.send_system_command(SC_RESTORE);
+        }
+
+        unsafe {
+            let foreground = GetForegroundWindow();
+            let foreground_thread = GetWindowThreadProcessId(foreground, None);
+            let current_thread = GetCurrentThreadId();
+            // Attaching our input queue to the foreground thread is what lets
+            // `SetForegroundWindow` bypass the foreground lock. After the attach, though,
+            // `SetForegroundWindow`/`BringWindowToTop` deliver synchronously to the attached
+            // thread; if its process is hung, that would block our UI thread indefinitely. Skip
+            // the attach when the foreground window is unresponsive and fall back to the taskbar
+            // flash. A small TOCTOU gap remains (the target could hang after this check); it is
+            // inherent to this approach.
+            let attached = foreground_thread != 0
+                && foreground_thread != current_thread
+                && !IsHungAppWindow(foreground).as_bool()
+                && AttachThreadInput(current_thread, foreground_thread, true).as_bool();
+
+            let _ = SetForegroundWindow(hwnd);
+            let _ = BringWindowToTop(hwnd);
+            let _ = SetActiveWindow(hwnd);
+
+            if attached {
+                let _ = AttachThreadInput(current_thread, foreground_thread, false);
+            }
+        }
     }
 
     pub fn set_cursor(&self, cursor: Cursor) {

--- a/native/desktop-win32/src/win32/window_api.rs
+++ b/native/desktop-win32/src/win32/window_api.rs
@@ -309,6 +309,14 @@ pub extern "C" fn window_show(window_ptr: WindowPtr) {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn window_force_focus(window_ptr: WindowPtr) {
+    with_window(&window_ptr, "window_force_focus", |window| {
+        window.force_focus();
+        Ok(())
+    });
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn window_request_redraw(window_ptr: WindowPtr) {
     with_window(&window_ptr, "window_request_redraw", |window| {
         window.request_redraw()?;

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
@@ -90,7 +90,7 @@ class SkottieWindow(app: Application) : SkikoWindowWin32(app) {
 class ApplicationState(private val app: Application) : AutoCloseable {
     private val windows = mutableMapOf<WindowId, SkottieWindow>()
 
-    fun createWindow() {
+    fun createWindow(focusOnCreate: Boolean = false) {
         val windowParams = WindowParams(
             size = LogicalSize(width = 640f, height = 480f),
             title = "Sample Window",
@@ -106,6 +106,13 @@ class ApplicationState(private val app: Application) : AutoCloseable {
         window.window.create(windowParams)
         window.window.setMinSize(LogicalSize(320.0f, 240.0f))
         window.window.show()
+        // Force focus only for the initial startup window, so it comes to the front even when
+        // the app is launched from a terminal/IDE that currently owns the foreground. Windows
+        // opened mid-session (e.g. Ctrl+N) intentionally follow the normal OS foreground policy
+        // and don't steal focus from whatever the user is doing.
+        if (focusOnCreate) {
+            window.window.forceFocus()
+        }
 
         val appearance = Appearance.getCurrent()
         Logger.debug { "Current appearance: $appearance" }
@@ -152,7 +159,7 @@ fun main(args: Array<String>) {
     Application().use { app ->
         ApplicationState(app).use { state ->
             app.onStartup {
-                state.createWindow()
+                state.createWindow(focusOnCreate = true)
             }
             app.runEventLoop { windowId, event ->
                 state.handleEvent(event, windowId)


### PR DESCRIPTION
Adds a force_focus path that works around Windows' foreground-activation lock so an app launched from a terminal/IDE (which doesn't own the foreground) can bring its window to the front and focus it, instead of only flashing the taskbar button.

- window.rs: force_focus() attaches our input queue to the foreground thread to bypass the lock, then SetForegroundWindow/BringWindowToTop/ SetActiveWindow. Restores a minimized window via the synchronous WM_SYSCOMMAND/SC_RESTORE path, and skips the attach when the foreground window is hung (IsHungAppWindow) to avoid blocking the UI thread.
- window_api.rs: window_force_focus FFI export.
- Window.kt: forceFocus() binding.
- sample: focus only the startup window; mid-session (Ctrl+N) windows follow the normal OS foreground policy.