### PR TITLE
feat(linux): window inset for resize handles 

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Application.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Application.kt
@@ -36,6 +36,7 @@ public data class WindowParams(
     val title: String,
     val size: LogicalSize? = null,
     val minSize: LogicalSize? = null,
+    val insets: LogicalSideOffsets = LogicalSideOffsets.Zero,
     val preferClientSideDecoration: Boolean = false,
     val renderingMode: RenderingMode = RenderingMode.Auto,
 ) {
@@ -56,6 +57,7 @@ public data class WindowParams(
         val nativeWindowParams = NativeWindowParams.allocate(arena)
         NativeWindowParams.size(nativeWindowParams, size.toNative(arena))
         NativeWindowParams.min_size(nativeWindowParams, minSize.toNative(arena))
+        NativeWindowParams.insets(nativeWindowParams, insets.toNative(arena))
         NativeWindowParams.title(nativeWindowParams, title.toNativeUtf8(arena))
         NativeWindowParams.app_id(nativeWindowParams, appId.toNativeUtf8(arena))
         NativeWindowParams.prefer_client_side_decoration(nativeWindowParams, preferClientSideDecoration)

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
@@ -28,6 +28,7 @@ import org.jetbrains.desktop.linux.generated.NativeKeyDownEvent
 import org.jetbrains.desktop.linux.generated.NativeKeyUpEvent
 import org.jetbrains.desktop.linux.generated.NativeLogicalPoint
 import org.jetbrains.desktop.linux.generated.NativeLogicalRect
+import org.jetbrains.desktop.linux.generated.NativeLogicalSideOffsets
 import org.jetbrains.desktop.linux.generated.NativeLogicalSize
 import org.jetbrains.desktop.linux.generated.NativeModifiersChangedEvent
 import org.jetbrains.desktop.linux.generated.NativeMouseDownEvent
@@ -38,6 +39,7 @@ import org.jetbrains.desktop.linux.generated.NativeMouseUpEvent
 import org.jetbrains.desktop.linux.generated.NativeNotificationClosedEvent
 import org.jetbrains.desktop.linux.generated.NativeNotificationShownEvent
 import org.jetbrains.desktop.linux.generated.NativeOpenFileDialogParams
+import org.jetbrains.desktop.linux.generated.NativePhysicalSideOffsets
 import org.jetbrains.desktop.linux.generated.NativePhysicalSize
 import org.jetbrains.desktop.linux.generated.NativeSaveFileDialogParams
 import org.jetbrains.desktop.linux.generated.NativeScrollData
@@ -135,6 +137,29 @@ internal fun LogicalRect.toNative(arena: Arena): MemorySegment {
     NativeLogicalRect.height(result, height)
     return result
 }
+
+internal fun LogicalSideOffsets.toNative(arena: Arena): MemorySegment {
+    val result = NativeLogicalSideOffsets.allocate(arena)
+    NativeLogicalSideOffsets.top(result, top)
+    NativeLogicalSideOffsets.left(result, left)
+    NativeLogicalSideOffsets.bottom(result, bottom)
+    NativeLogicalSideOffsets.right(result, right)
+    return result
+}
+
+internal fun LogicalSideOffsets.Companion.fromNative(s: MemorySegment) = LogicalSideOffsets(
+    top = NativeLogicalSideOffsets.top(s),
+    left = NativeLogicalSideOffsets.left(s),
+    bottom = NativeLogicalSideOffsets.bottom(s),
+    right = NativeLogicalSideOffsets.right(s),
+)
+
+internal fun PhysicalSideOffsets.Companion.fromNative(s: MemorySegment) = PhysicalSideOffsets(
+    top = NativePhysicalSideOffsets.top(s),
+    left = NativePhysicalSideOffsets.left(s),
+    bottom = NativePhysicalSideOffsets.bottom(s),
+    right = NativePhysicalSideOffsets.right(s),
+)
 
 internal fun PhysicalSize.Companion.fromNative(s: MemorySegment) = PhysicalSize(
     width = NativePhysicalSize.width(s),
@@ -912,7 +937,9 @@ internal fun Event.Companion.fromNative(s: MemorySegment, app: Application): Eve
             val nativeEvent = NativeEvent.window_configure(s)
             Event.WindowConfigure(
                 windowId = NativeWindowConfigureEvent.window_id(nativeEvent),
-                size = LogicalSize.fromNative(NativeWindowConfigureEvent.size(nativeEvent)),
+                logicalGeometrySize = LogicalSize.fromNative(NativeWindowConfigureEvent.logical_geometry_size(nativeEvent)),
+                logicalBufferSize = LogicalSize.fromNative(NativeWindowConfigureEvent.logical_buffer_size(nativeEvent)),
+                logicalInsets = LogicalSideOffsets.fromNative(NativeWindowConfigureEvent.logical_insets(nativeEvent)),
                 active = NativeWindowConfigureEvent.active(nativeEvent),
                 maximized = NativeWindowConfigureEvent.maximized(nativeEvent),
                 fullscreen = NativeWindowConfigureEvent.fullscreen(nativeEvent),
@@ -953,7 +980,8 @@ internal fun Event.Companion.fromNative(s: MemorySegment, app: Application): Eve
             Event.WindowDraw(
                 windowId = NativeWindowDrawEvent.window_id(nativeEvent),
                 softwareDrawData = SoftwareDrawData.fromNative(NativeWindowDrawEvent.software_draw_data(nativeEvent)),
-                size = PhysicalSize.fromNative(NativeWindowDrawEvent.physical_size(nativeEvent)),
+                physicalSize = PhysicalSize.fromNative(NativeWindowDrawEvent.physical_size(nativeEvent)),
+                physicalInsets = PhysicalSideOffsets.fromNative(NativeWindowDrawEvent.physical_insets(nativeEvent)),
                 scale = NativeWindowDrawEvent.scale(nativeEvent),
             )
         }

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Converters.kt
@@ -980,7 +980,8 @@ internal fun Event.Companion.fromNative(s: MemorySegment, app: Application): Eve
             Event.WindowDraw(
                 windowId = NativeWindowDrawEvent.window_id(nativeEvent),
                 softwareDrawData = SoftwareDrawData.fromNative(NativeWindowDrawEvent.software_draw_data(nativeEvent)),
-                physicalSize = PhysicalSize.fromNative(NativeWindowDrawEvent.physical_size(nativeEvent)),
+                physicalGeometrySize = PhysicalSize.fromNative(NativeWindowDrawEvent.physical_geometry_size(nativeEvent)),
+                physicalBufferSize = PhysicalSize.fromNative(NativeWindowDrawEvent.physical_buffer_size(nativeEvent)),
                 physicalInsets = PhysicalSideOffsets.fromNative(NativeWindowDrawEvent.physical_insets(nativeEvent)),
                 scale = NativeWindowDrawEvent.scale(nativeEvent),
             )

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Event.kt
@@ -313,7 +313,9 @@ public sealed class Event {
     @ConsistentCopyVisibility
     public data class WindowConfigure internal constructor(
         val windowId: WindowId,
-        val size: LogicalSize,
+        val logicalGeometrySize: LogicalSize,
+        val logicalBufferSize: LogicalSize,
+        val logicalInsets: LogicalSideOffsets,
         val active: Boolean,
         val maximized: Boolean,
         val fullscreen: Boolean,
@@ -348,7 +350,8 @@ public sealed class Event {
     public data class WindowDraw internal constructor(
         val windowId: WindowId,
         val softwareDrawData: SoftwareDrawData?,
-        val size: PhysicalSize,
+        val physicalSize: PhysicalSize,
+        val physicalInsets: PhysicalSideOffsets,
         val scale: Double,
     ) : Event()
 

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Event.kt
@@ -350,7 +350,8 @@ public sealed class Event {
     public data class WindowDraw internal constructor(
         val windowId: WindowId,
         val softwareDrawData: SoftwareDrawData?,
-        val physicalSize: PhysicalSize,
+        val physicalGeometrySize: PhysicalSize,
+        val physicalBufferSize: PhysicalSize,
         val physicalInsets: PhysicalSideOffsets,
         val scale: Double,
     ) : Event()

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Geometry.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Geometry.kt
@@ -54,3 +54,42 @@ public data class LogicalRect(
     val width: Int,
     val height: Int,
 )
+
+public data class LogicalSideOffsets(
+    val top: Int,
+    val left: Int,
+    val bottom: Int,
+    val right: Int,
+) {
+    public constructor(all: Int) : this(all, all, all, all)
+
+    init {
+        require(top >= 0 && left >= 0 && bottom >= 0 && right >= 0) {
+            "Invalid SideOffsets (top, left, bottom and right must be positive)"
+        }
+    }
+
+    public companion object {
+        public val Zero: LogicalSideOffsets = LogicalSideOffsets(0)
+    }
+
+    public fun toPhysical(scale: Double): PhysicalSideOffsets = PhysicalSideOffsets(
+        top = (top.toDouble() * scale).roundToInt(),
+        left = (left.toDouble() * scale).roundToInt(),
+        bottom = (bottom.toDouble() * scale).roundToInt(),
+        right = (right.toDouble() * scale).roundToInt(),
+    )
+}
+
+public data class PhysicalSideOffsets(
+    val top: PhysicalPixels,
+    val left: PhysicalPixels,
+    val bottom: PhysicalPixels,
+    val right: PhysicalPixels,
+) {
+    public constructor(all: Int) : this(all, all, all, all)
+
+    public companion object {
+        public val Zero: PhysicalSideOffsets = PhysicalSideOffsets(0)
+    }
+}

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Window.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/linux/Window.kt
@@ -41,9 +41,21 @@ public class Window internal constructor(
         return "${javaClass.typeName}(windowId=$windowId, appPtr=0x${appPtr.address().toString(16)})"
     }
 
-    public fun getSize(): LogicalSize {
+    public fun getLogicalGeometrySize(): LogicalSize {
         return Arena.ofConfined().use { arena ->
-            LogicalSize.fromNative(ffiDownCall { desktop_linux_h.window_get_size(arena, appPtr, windowId) })
+            LogicalSize.fromNative(ffiDownCall { desktop_linux_h.window_get_logical_geometry_size(arena, appPtr, windowId) })
+        }
+    }
+
+    public fun getLogicalBufferSize(): LogicalSize {
+        return Arena.ofConfined().use { arena ->
+            LogicalSize.fromNative(ffiDownCall { desktop_linux_h.window_get_logical_buffer_size(arena, appPtr, windowId) })
+        }
+    }
+
+    public fun getPhysicalBufferSize(): PhysicalSize {
+        return Arena.ofConfined().use { arena ->
+            PhysicalSize.fromNative(ffiDownCall { desktop_linux_h.window_get_physical_buffer_size(arena, appPtr, windowId) })
         }
     }
 

--- a/kotlin-desktop-toolkit/src/testWayland/kotlin/org/jetbrains/desktop/linux/tests/WaylandTests.kt
+++ b/kotlin-desktop-toolkit/src/testWayland/kotlin/org/jetbrains/desktop/linux/tests/WaylandTests.kt
@@ -26,6 +26,7 @@ import org.jetbrains.desktop.linux.KotlinDesktopToolkit
 import org.jetbrains.desktop.linux.LogLevel
 import org.jetbrains.desktop.linux.LogicalPoint
 import org.jetbrains.desktop.linux.LogicalRect
+import org.jetbrains.desktop.linux.LogicalSideOffsets
 import org.jetbrains.desktop.linux.LogicalSize
 import org.jetbrains.desktop.linux.MouseButton
 import org.jetbrains.desktop.linux.PhysicalSize
@@ -933,7 +934,9 @@ internal data class InitialSettings(
 internal data class ExpectedWindowConfigure(
     val checkWindowCapabilities: (WindowCapabilities) -> Unit,
     val windowId: WindowId,
-    val size: LogicalSize,
+    val logicalGeometrySize: LogicalSize,
+    val logicalBufferSize: LogicalSize,
+    val logicalInsets: LogicalSideOffsets,
     val active: Boolean,
     val maximized: Boolean,
     val fullscreen: Boolean,
@@ -950,8 +953,14 @@ internal data class ExpectedWindowConfigure(
         if (windowId != event.windowId) {
             failures.add("\nWindowConfigure.windowId(expected=$windowId, actual=${event.windowId})$msg")
         }
-        if (size != event.size) {
-            failures.add("\nWindowConfigure.size(expected=$size, actual=${event.size})$msg")
+        if (logicalGeometrySize != event.logicalGeometrySize) {
+            failures.add("\nWindowConfigure.logicalGeometrySize(expected=$logicalGeometrySize, actual=${event.logicalGeometrySize})$msg")
+        }
+        if (logicalBufferSize != event.logicalBufferSize) {
+            failures.add("\nWindowConfigure.logicalBufferSize(expected=$logicalBufferSize, actual=${event.logicalBufferSize})$msg")
+        }
+        if (logicalInsets != event.logicalInsets) {
+            failures.add("\nWindowConfigure.logicalInsets(expected=$logicalInsets, actual=${event.logicalInsets})$msg")
         }
         if (active != event.active) {
             failures.add("\nWindowConfigure.active(expected=$active, actual=${event.active})$msg")
@@ -1093,7 +1102,7 @@ abstract class WaylandTestsBase {
     ): ApplicationConfig {
         return ApplicationConfig(
             eventHandler = { event ->
-                val shouldDraw = event is Event.WindowDraw && lastDrawEvents[event.windowId]?.size != event.size
+                val shouldDraw = event is Event.WindowDraw && lastDrawEvents[event.windowId]?.physicalBufferSize != event.physicalBufferSize
                 if (shouldDraw) {
                     lastDrawEvents[event.windowId] = event
                 }
@@ -1101,11 +1110,11 @@ abstract class WaylandTestsBase {
                     // Need to draw window content in order for Sway to activate it
                     if (shouldDraw) {
                         event.softwareDrawData?.let { softwareDrawData ->
-                            performSoftwareDrawing(event.size, softwareDrawData) { canvas ->
+                            performSoftwareDrawing(event.physicalBufferSize, softwareDrawData) { canvas ->
                                 canvas.clear(SkColor.WHITE)
                                 SkPaint().use { paint ->
                                     paint.color = SkColor.RED
-                                    canvas.drawRect(SkRect.makeXYWH(event.size.width - 10f, event.size.height - 10f, 10f, 10f), paint)
+                                    canvas.drawRect(SkRect.makeXYWH(event.physicalBufferSize.width - 10f, event.physicalBufferSize.height - 10f, 10f, 10f), paint)
                                 }
                             }
                             EventHandlerResult.Stop
@@ -1954,21 +1963,23 @@ class WaylandTests : WaylandTestsBase() {
 //        log("$screens")
         val screen = screens.firstOrNull()
         assertNotNull(screen)
-        val fullscreenWindowSize = screen.size
+        val fullscreenGeometrySize = screen.size
         assertEquals(LogicalPoint(0.0, 0.0), screen.origin)
         if (screen.name != "WL-1") {
             assertEquals("HEADLESS-1", screen.name)
         }
         assertNotEquals(0, screen.screenId)
 
-        val windowParams = defaultWindowParams().copy(minSize = LogicalSize(width = 100, height = 70))
-        val requestedSize = assertNotNull(windowParams.size)
+        val windowParams = defaultWindowParams().copy(minSize = LogicalSize(width = 100, height = 70), insets = LogicalSideOffsets.Zero)
+        val requestedGeometrySize = assertNotNull(windowParams.size)
         val window = ui { app.createWindow(windowParams) }
 
         var expectedConfigureEvent = ExpectedWindowConfigure(
             checkWindowCapabilities,
             windowId = windowParams.windowId,
-            size = requestedSize,
+            logicalGeometrySize = requestedGeometrySize,
+            logicalBufferSize = requestedGeometrySize,
+            logicalInsets = LogicalSideOffsets.Zero,
             active = false,
             maximized = false,
             fullscreen = false,
@@ -1991,7 +2002,8 @@ class WaylandTests : WaylandTestsBase() {
             assertEquals(windowParams.windowId, event.windowId)
             scale = event.scale
 //            assertEquals(1.0, event.scale) // https://github.com/swaywm/sway/issues/7668
-            assertEquals(requestedSize.toPhysical(event.scale), event.size)
+            assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalGeometrySize)
+            assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalBufferSize)
         }
 
         withNextEvent { event ->
@@ -2031,7 +2043,8 @@ class WaylandTests : WaylandTestsBase() {
                 } else {
                     scale = event.scale
                 }
-                assertEquals(requestedSize.toPhysical(event.scale), event.size)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalGeometrySize)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalBufferSize)
                 getNextEvent()
             } else {
                 event
@@ -2090,7 +2103,8 @@ class WaylandTests : WaylandTestsBase() {
             val mouseMovedEvent = if (event is Event.WindowDraw) {
                 assertEquals(windowParams.windowId, event.windowId)
                 assertEquals(scale, event.scale)
-                assertEquals(requestedSize.toPhysical(event.scale), event.size)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalGeometrySize)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalBufferSize)
                 getNextEvent()
             } else {
                 event
@@ -2123,7 +2137,8 @@ class WaylandTests : WaylandTestsBase() {
             val mouseExitedEvent = if (event is Event.WindowDraw) {
                 assertEquals(windowParams.windowId, event.windowId)
                 assertEquals(scale, event.scale)
-                assertEquals(requestedSize.toPhysical(event.scale), event.size)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalGeometrySize)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalBufferSize)
                 getNextEvent()
             } else {
                 event
@@ -2148,7 +2163,7 @@ class WaylandTests : WaylandTestsBase() {
                 ui { window.setFullScreen() }
             }
 
-            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = true, size = fullscreenWindowSize)
+            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = true, logicalGeometrySize = fullscreenGeometrySize, logicalBufferSize = fullscreenGeometrySize)
             withNextEvent { event ->
                 expectedConfigureEvent.assertEquals(event, "fullscreen configure, useWm=$useWm")
             }
@@ -2158,7 +2173,8 @@ class WaylandTests : WaylandTestsBase() {
                 assertInstanceOf<Event.WindowDraw>(event)
                 assertEquals(windowParams.windowId, event.windowId)
                 assertEquals(scale, event.scale)
-                assertEquals(lastScreenSize?.toPhysical(event.scale), event.size)
+                assertEquals(lastScreenSize?.toPhysical(event.scale), event.physicalGeometrySize)
+                assertEquals(lastScreenSize?.toPhysical(event.scale), event.physicalBufferSize)
             }
 
             withNextEvent { event ->
@@ -2187,7 +2203,7 @@ class WaylandTests : WaylandTestsBase() {
                 ui { window.unsetFullScreen() }
             }
 
-            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = false, size = requestedSize)
+            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = false, logicalGeometrySize = requestedGeometrySize, logicalBufferSize = requestedGeometrySize)
 
             withNextEvent { event ->
                 expectedConfigureEvent.assertEquals(event, "fullscreen exit configure, useWm=$useWm")
@@ -2198,7 +2214,8 @@ class WaylandTests : WaylandTestsBase() {
                 assertInstanceOf<Event.WindowDraw>(event)
                 assertEquals(windowParams.windowId, event.windowId)
                 assertEquals(scale, event.scale)
-                assertEquals(requestedSize.toPhysical(event.scale), event.size)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalGeometrySize)
+                assertEquals(requestedGeometrySize.toPhysical(event.scale), event.physicalBufferSize)
             }
 
             withNextEvent { event ->
@@ -2416,8 +2433,13 @@ class WaylandTests : WaylandTestsBase() {
     fun testMultipleWindowCreation() {
         run(defaultApplicationConfig())
 
-        val window1Params = defaultWindowParams()
-        val requestedWindow1Size = assertNotNull(window1Params.size)
+        val requestedWindow1Insets = LogicalSideOffsets(10)
+        val window1Params = defaultWindowParams().copy(insets = requestedWindow1Insets)
+        val requestedWindow1GeometrySize = assertNotNull(window1Params.size)
+        val requestedWindow1BufferSize = LogicalSize(
+            width = requestedWindow1GeometrySize.width + requestedWindow1Insets.left + requestedWindow1Insets.right,
+            height = requestedWindow1GeometrySize.height + requestedWindow1Insets.top + requestedWindow1Insets.bottom,
+        )
         val window1 = ui { app.createWindow(window1Params) }
 
         awaitEventOfType<Event.WindowDraw>(msg = "Draw first window") { event ->
@@ -2428,7 +2450,9 @@ class WaylandTests : WaylandTestsBase() {
         var expectedWindow1ConfigureEvent = ExpectedWindowConfigure(
             checkWindowCapabilities,
             windowId = window1Params.windowId,
-            size = requestedWindow1Size,
+            logicalGeometrySize = requestedWindow1GeometrySize,
+            logicalBufferSize = requestedWindow1BufferSize,
+            logicalInsets = requestedWindow1Insets,
             active = true,
             maximized = false,
             fullscreen = false,
@@ -2451,11 +2475,11 @@ class WaylandTests : WaylandTestsBase() {
 
         val window1WmId = wm.getFocusedWindowState()!!.getWindowId()
 
-        val requestedWindow2Size = LogicalSize(width = 300, height = 200)
+        val requestedWindow2GeometrySize = LogicalSize(width = 300, height = 200)
         val window2Params = WindowParams(
             windowId = 1,
             title = "Test Window 2",
-            size = requestedWindow2Size,
+            size = requestedWindow2GeometrySize,
             minSize = null,
             preferClientSideDecoration = true,
             renderingMode = RenderingMode.Software,
@@ -2470,7 +2494,9 @@ class WaylandTests : WaylandTestsBase() {
         var expectedWindow2ConfigureEvent = ExpectedWindowConfigure(
             checkWindowCapabilities,
             windowId = window2Params.windowId,
-            size = requestedWindow2Size,
+            logicalGeometrySize = requestedWindow2GeometrySize,
+            logicalBufferSize = requestedWindow2GeometrySize,
+            logicalInsets = LogicalSideOffsets.Zero,
             active = true,
             maximized = false,
             fullscreen = false,
@@ -2576,10 +2602,15 @@ class WaylandTests : WaylandTestsBase() {
 
         wm.tileWindows(listOf(window2WmId, window1WmId))
 
-        val tiledWindowSize = wm.getMaximizedWindowSize(screen.name!!).let { LogicalSize(width = it.width / 2, height = it.height) }
+        val tiledWindowGeometrySize = wm.getMaximizedWindowSize(screen.name!!).let { LogicalSize(width = it.width / 2, height = it.height) }
+        val tiledWindow1BufferSize = LogicalSize(
+            width = tiledWindowGeometrySize.width + requestedWindow1Insets.left + requestedWindow1Insets.right,
+            height = tiledWindowGeometrySize.height + requestedWindow1Insets.top + requestedWindow1Insets.bottom,
+        )
         expectedWindow1ConfigureEvent =
             expectedWindow1ConfigureEvent.copy(
-                size = tiledWindowSize,
+                logicalGeometrySize = tiledWindowGeometrySize,
+                logicalBufferSize = tiledWindow1BufferSize,
                 tiledLeft = true,
                 tiledRight = true,
                 tiledTop = true,
@@ -2589,7 +2620,8 @@ class WaylandTests : WaylandTestsBase() {
         expectedWindow2ConfigureEvent =
             expectedWindow2ConfigureEvent.copy(
                 decorationMode = WindowDecorationMode.Server,
-                size = tiledWindowSize,
+                logicalGeometrySize = tiledWindowGeometrySize,
+                logicalBufferSize = tiledWindowGeometrySize,
                 tiledLeft = true,
                 tiledRight = true,
                 tiledTop = true,
@@ -2599,7 +2631,7 @@ class WaylandTests : WaylandTestsBase() {
         checkNextEvents(
             checks = mapOf(
                 "Window 1 tiled" to { event, _ ->
-                    if (event is Event.WindowConfigure && event.windowId == window1Params.windowId && event.size == tiledWindowSize) {
+                    if (event is Event.WindowConfigure && event.windowId == window1Params.windowId && event.logicalGeometrySize == tiledWindowGeometrySize) {
                         expectedWindow1ConfigureEvent.assertEquals(event)
                         true
                     } else {
@@ -2607,7 +2639,7 @@ class WaylandTests : WaylandTestsBase() {
                     }
                 },
                 "Window 2 tiled" to { event, _ ->
-                    if (event is Event.WindowConfigure && event.windowId == window2Params.windowId && event.size == tiledWindowSize) {
+                    if (event is Event.WindowConfigure && event.windowId == window2Params.windowId && event.logicalGeometrySize == tiledWindowGeometrySize) {
                         expectedWindow2ConfigureEvent.assertEquals(event)
                         true
                     } else {
@@ -3926,11 +3958,11 @@ text/plain;charset=utf-8
         val initialWindowData = createWindowAndWaitForFocus(windowParams)
         val window = initialWindowData.window
 
-        val requestedWindowSize = assertNotNull(windowParams.size)
-        assertEquals(requestedWindowSize, initialWindowData.configure.size)
+        val requestedWindowGeometrySize = assertNotNull(windowParams.size)
+        assertEquals(requestedWindowGeometrySize, initialWindowData.configure.logicalGeometrySize)
 
         val stateBefore = assertNotNull(wm.getFocusedWindowState())
-        assertEquals(requestedWindowSize, stateBefore.getClientAreaSize())
+        assertEquals(requestedWindowGeometrySize, stateBefore.getClientAreaSize())
 
         withMouseButtonDown(button) {
             awaitEventOfType<Event.MouseDown> { true }
@@ -3975,15 +4007,15 @@ text/plain;charset=utf-8
         val initialWindowData = createWindowAndWaitForFocus(windowParams)
         val window = initialWindowData.window
 
-        val requestedWindowSize = assertNotNull(windowParams.size)
-        assertEquals(requestedWindowSize, initialWindowData.configure.size)
+        val requestedWindowGeometrySize = assertNotNull(windowParams.size)
+        assertEquals(requestedWindowGeometrySize, initialWindowData.configure.logicalGeometrySize)
 
         val stateBefore = assertNotNull(wm.getFocusedWindowState())
-        assertEquals(requestedWindowSize, stateBefore.getClientAreaSize())
+        assertEquals(requestedWindowGeometrySize, stateBefore.getClientAreaSize())
 
         val expectedSize = LogicalSize(
-            width = (requestedWindowSize.width - expectedDecreaseX),
-            height = (requestedWindowSize.height - expectedDecreaseY),
+            width = (requestedWindowGeometrySize.width - expectedDecreaseX),
+            height = (requestedWindowGeometrySize.height - expectedDecreaseY),
         )
 
         // Move the mouse to the top-left part of the window
@@ -3996,7 +4028,7 @@ text/plain;charset=utf-8
             awaitEventOfType<Event.MouseExited> { true }
             moveMouseTo(mousePos.shifted(moveX, moveY))
             awaitEventOfType<Event.WindowConfigure> { event ->
-                event.active && event.size == expectedSize
+                event.active && event.logicalGeometrySize == expectedSize
             }
         }
         val stateAfter = assertNotNull(wm.getFocusedWindowState())
@@ -4279,7 +4311,7 @@ text/plain;charset=utf-8
             assertTrue(app.isEventLoopThread())
             when (event) {
                 is Event.WindowDraw -> {
-                    performSoftwareDrawing(event.size, event.softwareDrawData!!) { canvas ->
+                    performSoftwareDrawing(event.physicalBufferSize, event.softwareDrawData!!) { canvas ->
                         canvas.clear(SkColor.BLUE)
                     }
                     EventHandlerResult.Stop
@@ -4654,7 +4686,7 @@ text/plain;charset=utf-8
         val draw: (Event.WindowDraw) -> Unit = { event ->
             val softwareDrawData = event.softwareDrawData
             assertNotNull(softwareDrawData)
-            performSoftwareDrawing(event.size, softwareDrawData) { canvas ->
+            performSoftwareDrawing(event.physicalBufferSize, softwareDrawData) { canvas ->
                 canvas.clear(backgroundColor)
                 SkPaint().use { paint ->
                     paint.color = rectColor
@@ -4700,7 +4732,7 @@ text/plain;charset=utf-8
 
         ui { window.setFullScreen() }
         awaitEventOfType<Event.WindowDraw> {
-            it.size == lastScreenSize.toPhysical(it.scale)
+            it.physicalGeometrySize == lastScreenSize.toPhysical(it.scale)
         }
         ui {}
 

--- a/kotlin-desktop-toolkit/src/testWayland/kotlin/org/jetbrains/desktop/linux/tests/WaylandTests.kt
+++ b/kotlin-desktop-toolkit/src/testWayland/kotlin/org/jetbrains/desktop/linux/tests/WaylandTests.kt
@@ -1114,7 +1114,15 @@ abstract class WaylandTestsBase {
                                 canvas.clear(SkColor.WHITE)
                                 SkPaint().use { paint ->
                                     paint.color = SkColor.RED
-                                    canvas.drawRect(SkRect.makeXYWH(event.physicalBufferSize.width - 10f, event.physicalBufferSize.height - 10f, 10f, 10f), paint)
+                                    canvas.drawRect(
+                                        SkRect.makeXYWH(
+                                            event.physicalBufferSize.width - 10f,
+                                            event.physicalBufferSize.height - 10f,
+                                            10f,
+                                            10f,
+                                        ),
+                                        paint,
+                                    )
                                 }
                             }
                             EventHandlerResult.Stop
@@ -2163,7 +2171,12 @@ class WaylandTests : WaylandTestsBase() {
                 ui { window.setFullScreen() }
             }
 
-            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = true, logicalGeometrySize = fullscreenGeometrySize, logicalBufferSize = fullscreenGeometrySize)
+            expectedConfigureEvent =
+                expectedConfigureEvent.copy(
+                    fullscreen = true,
+                    logicalGeometrySize = fullscreenGeometrySize,
+                    logicalBufferSize = fullscreenGeometrySize,
+                )
             withNextEvent { event ->
                 expectedConfigureEvent.assertEquals(event, "fullscreen configure, useWm=$useWm")
             }
@@ -2203,7 +2216,12 @@ class WaylandTests : WaylandTestsBase() {
                 ui { window.unsetFullScreen() }
             }
 
-            expectedConfigureEvent = expectedConfigureEvent.copy(fullscreen = false, logicalGeometrySize = requestedGeometrySize, logicalBufferSize = requestedGeometrySize)
+            expectedConfigureEvent =
+                expectedConfigureEvent.copy(
+                    fullscreen = false,
+                    logicalGeometrySize = requestedGeometrySize,
+                    logicalBufferSize = requestedGeometrySize,
+                )
 
             withNextEvent { event ->
                 expectedConfigureEvent.assertEquals(event, "fullscreen exit configure, useWm=$useWm")
@@ -2631,7 +2649,10 @@ class WaylandTests : WaylandTestsBase() {
         checkNextEvents(
             checks = mapOf(
                 "Window 1 tiled" to { event, _ ->
-                    if (event is Event.WindowConfigure && event.windowId == window1Params.windowId && event.logicalGeometrySize == tiledWindowGeometrySize) {
+                    if (event is Event.WindowConfigure &&
+                        event.windowId == window1Params.windowId &&
+                        event.logicalGeometrySize == tiledWindowGeometrySize
+                    ) {
                         expectedWindow1ConfigureEvent.assertEquals(event)
                         true
                     } else {
@@ -2639,7 +2660,10 @@ class WaylandTests : WaylandTestsBase() {
                     }
                 },
                 "Window 2 tiled" to { event, _ ->
-                    if (event is Event.WindowConfigure && event.windowId == window2Params.windowId && event.logicalGeometrySize == tiledWindowGeometrySize) {
+                    if (event is Event.WindowConfigure &&
+                        event.windowId == window2Params.windowId &&
+                        event.logicalGeometrySize == tiledWindowGeometrySize
+                    ) {
                         expectedWindow2ConfigureEvent.assertEquals(event)
                         true
                     } else {

--- a/native/desktop-linux/examples/sample_linux/sample_linux.rs
+++ b/native/desktop-linux/examples/sample_linux/sample_linux.rs
@@ -6,11 +6,14 @@ use desktop_common::{
     logger_api::{LogLevel, LoggerConfiguration, logger_init_impl},
 };
 use desktop_linux::linux::application_api::{FfiDragAndDropQueryResponse, FfiSupportedActionsForMime, FfiTransferDataResponse};
-use desktop_linux::linux::geometry::PhysicalSize;
+use desktop_linux::linux::geometry::{LogicalSideOffsets, PhysicalPixels, PhysicalSideOffsets, PhysicalSize};
+use desktop_linux::linux::pointer_shapes_api::PointerShape;
 use desktop_linux::linux::screen::screen_list;
 use desktop_linux::linux::window_api::{
-    window_maximize, window_minimize, window_set_fullscreen, window_unmaximize, window_unset_fullscreen,
+    window_maximize, window_minimize, window_set_fullscreen, window_set_pointer_shape, window_start_resize, window_unmaximize,
+    window_unset_fullscreen,
 };
+use desktop_linux::linux::window_resize_edge_api::WindowResizeEdge;
 use desktop_linux::linux::{
     application_api::{
         AppPtr,
@@ -93,6 +96,7 @@ pub struct WindowState {
     pub opengl: Option<OpenglState>,
     last_received_path: Option<String>,
     last_draw_event_size_and_scale: Option<(PhysicalSize, f64)>,
+    last_logical_size: Option<LogicalSize>,
 }
 
 impl WindowState {
@@ -301,6 +305,12 @@ fn on_keydown(event: &KeyDownEvent, app_ptr: AppPtr<'_>, state: &mut State) -> b
                     window_id: new_window_id,
                     size: LogicalSize { width: 300, height: 200 },
                     min_size: LogicalSize { width: 0, height: 0 },
+                    insets: LogicalSideOffsets {
+                        top: 10,
+                        left: 10,
+                        bottom: 10,
+                        right: 10,
+                    },
                     title: BorrowedUtf8::new("Window N"),
                     app_id: BorrowedUtf8::new(APP_ID),
                     prefer_client_side_decoration: true,
@@ -425,6 +435,12 @@ fn on_application_started(state: &mut State) {
             window_id: window_1_id,
             size: LogicalSize { width: 200, height: 300 },
             min_size: LogicalSize { width: 100, height: 200 },
+            insets: LogicalSideOffsets {
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10,
+            },
             title: BorrowedUtf8::new("Window 1"),
             app_id: BorrowedUtf8::new(APP_ID),
             prefer_client_side_decoration: false,
@@ -440,6 +456,12 @@ fn on_application_started(state: &mut State) {
             window_id: window_2_id,
             size: LogicalSize { width: 300, height: 200 },
             min_size: LogicalSize { width: 200, height: 100 },
+            insets: LogicalSideOffsets {
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10,
+            },
             title: BorrowedUtf8::new("Window 2"),
             app_id: BorrowedUtf8::new(APP_ID),
             prefer_client_side_decoration: true,
@@ -489,6 +511,7 @@ extern "C" fn event_handler(event: &Event) -> bool {
             Event::WindowConfigure(data) => {
                 if let Some(window_state) = state.windows.get_mut(&data.window_id) {
                     window_state.active = data.active;
+                    window_state.last_logical_size = Some(data.logical_geometry_size);
                 }
                 true
             }
@@ -506,9 +529,15 @@ extern "C" fn event_handler(event: &Event) -> bool {
                     window_state.animation_tick();
 
                     if data.software_draw_data.canvas.is_null() {
-                        draw_opengl_triangle_with_init(data.physical_size, data.window_id, window_state);
+                        draw_opengl_triangle_with_init(data.physical_size, data.physical_insets, data.window_id, window_state);
                     } else {
-                        draw_software(&data.software_draw_data, data.physical_size, data.scale, window_state);
+                        draw_software(
+                            &data.software_draw_data,
+                            data.physical_size,
+                            data.physical_insets,
+                            data.scale,
+                            window_state,
+                        );
                     }
                     true
                 } else {
@@ -521,7 +550,17 @@ extern "C" fn event_handler(event: &Event) -> bool {
                 window_state.animation_tick();
 
                 if data.software_draw_data.canvas.is_null() {
-                    draw_opengl_triangle_with_init(data.physical_size, window_id, window_state);
+                    draw_opengl_triangle_with_init(
+                        data.physical_size,
+                        PhysicalSideOffsets {
+                            top: PhysicalPixels(0),
+                            left: PhysicalPixels(0),
+                            bottom: PhysicalPixels(0),
+                            right: PhysicalPixels(0),
+                        },
+                        window_id,
+                        window_state,
+                    );
                 } else {
                     draw_software_drag_icon(&data.software_draw_data, data.physical_size, data.scale);
                 }
@@ -542,40 +581,98 @@ extern "C" fn event_handler(event: &Event) -> bool {
                 }
                 true
             }
-            Event::MouseDown(data) => match data.button.0 {
-                MOUSE_BUTTON_LEFT => {
-                    if data.location_in_window.x.0 < DRAG_AND_DROP_LEFT_OF {
-                        let mime_types = if state.key_modifiers == KeyModifiers::Shift {
-                            ALL_MIMES
+            Event::MouseMoved(data) => {
+                if let Some(window) = state.windows.get_mut(&data.window_id) {
+                    let x = data.location_in_window.x.0;
+                    let y = data.location_in_window.y.0;
+
+                    let size = window.last_logical_size.unwrap_or_default();
+
+                    let resize_edge = get_resize_edge(x, y, size);
+                    if resize_edge == WindowResizeEdge::None {
+                        let pointer_shape = if x < DRAG_AND_DROP_LEFT_OF {
+                            PointerShape::Grab
                         } else {
-                            TEXT_MIME_TYPE
+                            PointerShape::Default
                         };
-                        let actions = DragAndDropActions(DragAndDropAction::Copy as u32 | DragAndDropAction::Move as u32);
-                        let drag_icon_size = LogicalSize { width: 300, height: 300 };
-                        window_start_drag_and_drop(
-                            app_ptr,
-                            data.window_id,
-                            BorrowedUtf8::new(mime_types),
-                            actions,
-                            RenderingMode::Auto,
-                            drag_icon_size,
-                        );
-                        if let Some(window_state) = state.windows.get_mut(&data.window_id) {
-                            window_state.drag_and_drop_source = true;
-                        }
+
+                        window_set_pointer_shape(app_ptr, data.window_id, pointer_shape);
+                    } else {
+                        debug!("Starting window resize: edge = {resize_edge:?}");
+
+                        // matching what gtk does:
+                        let pointer_shape = match resize_edge {
+                            WindowResizeEdge::Top => PointerShape::NResize,
+                            WindowResizeEdge::Bottom => PointerShape::SResize,
+                            WindowResizeEdge::Left => PointerShape::WResize,
+                            WindowResizeEdge::Right => PointerShape::EResize,
+                            WindowResizeEdge::TopLeft => PointerShape::NwResize,
+                            WindowResizeEdge::BottomRight => PointerShape::SeResize,
+                            WindowResizeEdge::BottomLeft => PointerShape::SwResize,
+                            WindowResizeEdge::TopRight => PointerShape::NeResize,
+                            WindowResizeEdge::None => unreachable!(),
+                        };
+
+                        window_set_pointer_shape(app_ptr, data.window_id, pointer_shape);
                     }
+
                     true
+                } else {
+                    false
                 }
-                MOUSE_BUTTON_MIDDLE => {
-                    application_primary_selection_paste(
-                        app_ptr,
-                        state.add_data_request_source(data.window_id),
-                        BorrowedUtf8::new(TEXT_MIME_TYPE),
-                    );
-                    true
+            }
+            Event::MouseDown(data) => {
+                if let Some(window) = state.windows.get_mut(&data.window_id) {
+                    let x = data.location_in_window.x.0;
+                    let y = data.location_in_window.y.0;
+
+                    let size = window.last_logical_size.unwrap_or_default();
+
+                    let resize_edge = get_resize_edge(x, y, size);
+                    if resize_edge == WindowResizeEdge::None {
+                        match data.button.0 {
+                            MOUSE_BUTTON_LEFT => {
+                                if x < DRAG_AND_DROP_LEFT_OF {
+                                    let mime_types = if state.key_modifiers == KeyModifiers::Shift {
+                                        ALL_MIMES
+                                    } else {
+                                        TEXT_MIME_TYPE
+                                    };
+                                    let actions = DragAndDropActions(DragAndDropAction::Copy as u32 | DragAndDropAction::Move as u32);
+                                    let drag_icon_size = LogicalSize { width: 300, height: 300 };
+                                    window_start_drag_and_drop(
+                                        app_ptr,
+                                        data.window_id,
+                                        BorrowedUtf8::new(mime_types),
+                                        actions,
+                                        RenderingMode::Auto,
+                                        drag_icon_size,
+                                    );
+                                    window.drag_and_drop_source = true;
+                                }
+                                true
+                            }
+                            MOUSE_BUTTON_MIDDLE => {
+                                application_primary_selection_paste(
+                                    app_ptr,
+                                    state.add_data_request_source(data.window_id),
+                                    BorrowedUtf8::new(TEXT_MIME_TYPE),
+                                );
+                                true
+                            }
+                            _ => false,
+                        }
+                    } else {
+                        debug!("Starting window reisize: edge = {resize_edge:?}");
+
+                        window_start_resize(app_ptr, data.window_id, resize_edge);
+
+                        true
+                    }
+                } else {
+                    false
                 }
-                _ => false,
-            },
+            }
             Event::ModifiersChanged(data) => {
                 state.key_modifiers = data.modifiers;
                 true
@@ -705,6 +802,30 @@ extern "C" fn event_handler(event: &Event) -> bool {
             _ => false,
         }
     })
+}
+
+fn get_resize_edge(x: f64, y: f64, size: LogicalSize) -> WindowResizeEdge {
+    let w = f64::from(size.width);
+    let h = f64::from(size.height);
+
+    let is_top = y < 0.0;
+    let is_bottom = y > h;
+    let is_left = x < 0.0;
+    let is_right = x > w;
+
+    debug!("get resize edge: top = {is_top}, bottom = {is_bottom}, left = {is_left}, right = {is_right}");
+
+    match () {
+        () if is_top && is_left => WindowResizeEdge::TopLeft,
+        () if is_top && is_right => WindowResizeEdge::TopRight,
+        () if is_bottom && is_left => WindowResizeEdge::BottomLeft,
+        () if is_bottom && is_right => WindowResizeEdge::BottomRight,
+        () if is_top => WindowResizeEdge::Top,
+        () if is_bottom => WindowResizeEdge::Bottom,
+        () if is_left => WindowResizeEdge::Left,
+        () if is_right => WindowResizeEdge::Right,
+        () => WindowResizeEdge::None,
+    }
 }
 
 fn on_desktop_settings_change(s: &FfiDesktopSetting, state: &mut State) {

--- a/native/desktop-linux/examples/sample_linux/sample_linux.rs
+++ b/native/desktop-linux/examples/sample_linux/sample_linux.rs
@@ -519,9 +519,9 @@ extern "C" fn event_handler(event: &Event) -> bool {
                 if let Some(window_state) = state.windows.get_mut(&data.window_id) {
                     if window_state
                         .last_draw_event_size_and_scale
-                        .replace((data.physical_size, data.scale))
+                        .replace((data.physical_buffer_size, data.scale))
                         .is_none_or(|(previous_size, previous_scale)| {
-                            previous_size != data.physical_size || (previous_scale - data.scale).abs() > 0.01
+                            previous_size != data.physical_buffer_size || (previous_scale - data.scale).abs() > 0.01
                         })
                     {
                         debug!("different draw data: {event:?}");
@@ -529,11 +529,11 @@ extern "C" fn event_handler(event: &Event) -> bool {
                     window_state.animation_tick();
 
                     if data.software_draw_data.canvas.is_null() {
-                        draw_opengl_triangle_with_init(data.physical_size, data.physical_insets, data.window_id, window_state);
+                        draw_opengl_triangle_with_init(data.physical_buffer_size, data.physical_insets, data.window_id, window_state);
                     } else {
                         draw_software(
                             &data.software_draw_data,
-                            data.physical_size,
+                            data.physical_buffer_size,
                             data.physical_insets,
                             data.scale,
                             window_state,

--- a/native/desktop-linux/examples/sample_linux/sample_linux.rs
+++ b/native/desktop-linux/examples/sample_linux/sample_linux.rs
@@ -813,7 +813,7 @@ fn get_resize_edge(x: f64, y: f64, size: LogicalSize) -> WindowResizeEdge {
     let is_left = x < 0.0;
     let is_right = x > w;
 
-    debug!("get resize edge: top = {is_top}, bottom = {is_bottom}, left = {is_left}, right = {is_right}");
+    // debug!("get resize edge: top = {is_top}, bottom = {is_bottom}, left = {is_left}, right = {is_right}");
 
     match () {
         () if is_top && is_left => WindowResizeEdge::TopLeft,

--- a/native/desktop-linux/examples/sample_linux/sample_linux_draw.rs
+++ b/native/desktop-linux/examples/sample_linux/sample_linux_draw.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ffi::CStr};
 use crate::sample_linux::WindowState;
 use desktop_linux::linux::application_api::application_get_egl_proc_func;
 use desktop_linux::linux::events::{SoftwareDrawData, WindowId};
-use desktop_linux::linux::geometry::PhysicalSize;
+use desktop_linux::linux::geometry::{PhysicalSideOffsets, PhysicalSize};
 use gles30::{
     GL_COLOR_BUFFER_BIT, GL_COMPILE_STATUS, GL_DEPTH_BUFFER_BIT, GL_FLOAT, GL_FRAGMENT_SHADER, GL_LINK_STATUS, GL_TRIANGLES,
     GL_VERTEX_SHADER, GLchar, GLenum, GLint, GLuint, GlFns,
@@ -88,12 +88,26 @@ void main()
 }
 
 /// Draw a triangle using the shader pair created in `Init()`
-fn draw_opengl_triangle(gl: &GlFns, program: GLuint, physical_size: PhysicalSize, animation_progress: f32) {
-    //    debug!("draw_opengl_triangle, program = {program}, event = {data:?}");
+fn draw_opengl_triangle(
+    gl: &GlFns,
+    program: GLuint,
+    physical_size: PhysicalSize,
+    physical_insets: PhysicalSideOffsets,
+    animation_progress: f32,
+) {
     let v_vertices: [f32; 6] = [animation_progress, 1.0, -1.0, -1.0, 1.0, -1.0];
+
+    let vp_width = physical_size.width.0 - physical_insets.left.0 - physical_insets.right.0;
+    let vp_height = physical_size.height.0 - physical_insets.top.0 - physical_insets.bottom.0;
+    let y_offset = physical_size.height.0 - vp_height - physical_insets.top.0;
+
     unsafe {
-        gl.Viewport(0, 0, physical_size.width.0, physical_size.height.0);
+        gl.Enable(gles30::GL_SCISSOR_TEST);
+
+        gl.Scissor(physical_insets.left.0, y_offset, vp_width, vp_height);
+        gl.Viewport(physical_insets.left.0, y_offset, vp_width, vp_height);
         gl.Clear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
         gl.UseProgram(program);
         //let v_position = gl.GetAttribLocation)(program, c"vPosition".as_ptr());
         //assert!(v_position != -1);
@@ -101,10 +115,17 @@ fn draw_opengl_triangle(gl: &GlFns, program: GLuint, physical_size: PhysicalSize
         gl.VertexAttribPointer(V_POSITION, 2, GL_FLOAT, 0, 0, v_vertices.as_ptr().cast());
         gl.EnableVertexAttribArray(V_POSITION);
         gl.DrawArrays(GL_TRIANGLES, 0, 3);
+
+        gl.Disable(gles30::GL_SCISSOR_TEST);
     }
 }
 
-pub fn draw_opengl_triangle_with_init(physical_size: PhysicalSize, window_id: WindowId, window_state: &mut WindowState) {
+pub fn draw_opengl_triangle_with_init(
+    physical_size: PhysicalSize,
+    physical_insets: PhysicalSideOffsets,
+    window_id: WindowId,
+    window_state: &mut WindowState,
+) {
     let opengl_state = window_state.opengl.get_or_insert_with(|| {
         let egl_lib = application_get_egl_proc_func();
         let gl = unsafe { GlFns::load_with(|name| (egl_lib.f)(egl_lib.ctx, name)) };
@@ -124,64 +145,98 @@ pub fn draw_opengl_triangle_with_init(physical_size: PhysicalSize, window_id: Wi
         1.0 - ((window_state.animation_progress - 100.) / 50.)
     };
 
-    draw_opengl_triangle(&opengl_state.gl, *program, physical_size, animation_progress);
+    draw_opengl_triangle(&opengl_state.gl, *program, physical_size, physical_insets, animation_progress);
 }
 
 #[allow(clippy::many_single_char_names)]
-pub fn draw_software(data: &SoftwareDrawData, physical_size: PhysicalSize, scale: f64, window_state: &WindowState) {
+#[allow(clippy::cast_sign_loss)]
+pub fn draw_software(
+    data: &SoftwareDrawData,
+    physical_size: PhysicalSize,
+    physical_insets: PhysicalSideOffsets,
+    scale: f64,
+    window_state: &WindowState,
+) {
     const BYTES_PER_PIXEL: u8 = 4;
     let drag_source_indicator_heigh = 100. * scale;
     let canvas = {
         let len = usize::try_from(physical_size.height.0 * data.stride).unwrap();
         unsafe { std::slice::from_raw_parts_mut(data.canvas, len) }
     };
-    let w = f64::from(physical_size.width.0);
-    let h = f64::from(physical_size.height.0);
+    let outer_w = f64::from(physical_size.width.0);
+    let outer_h = f64::from(physical_size.height.0);
+
+    let p_top = f64::from(physical_insets.top.0);
+    let p_left = f64::from(physical_insets.left.0);
+    let p_bottom = f64::from(physical_insets.bottom.0);
+    let p_right = f64::from(physical_insets.right.0);
+
+    let w = outer_w - p_left - p_right;
+    let h = outer_h - p_top - p_bottom;
+
     let line_thickness = 5.0 * scale;
 
     // Order of bytes in `pixel` is [b, g, r, a] (for the Argb8888 format)
-    for (pixel, i) in canvas.chunks_exact_mut(BYTES_PER_PIXEL.into()).zip(1u32..) {
-        let i = f64::from(i);
-        let x = i % w;
-        let y = (i / f64::from(data.stride)) * f64::from(BYTES_PER_PIXEL);
-        if between(
-            x,
-            DRAG_AND_DROP_LEFT_OF * scale,
-            DRAG_AND_DROP_LEFT_OF.mul_add(scale, line_thickness),
-        ) {
-            pixel[0] = 0;
-            pixel[1] = 0;
-            pixel[2] = 0;
-        } else if between(x, line_thickness,  line_thickness * 2.0)  // left border
-           || between(y, line_thickness,  line_thickness * 2.0)  // top border
-           || between(x, line_thickness.mul_add(-2.0, w), w - line_thickness)  // right border
-           || between(y, line_thickness.mul_add(-2.0, h), h - line_thickness)  // bottom border
-           || between(x, (i / h) - (line_thickness / 2.0), (i / h) + (line_thickness / 2.0))
-        {
-            pixel[0] = 0;
-            pixel[1] = 0;
-            pixel[2] = 255;
-        } else if x < DRAG_AND_DROP_LEFT_OF
-            && window_state.drag_and_drop_source
-            && between(y, drag_source_indicator_heigh, drag_source_indicator_heigh + line_thickness)
-        {
-            pixel[0] = 255;
-            pixel[1] = 0;
-            pixel[2] = 0;
-        } else if x < DRAG_AND_DROP_LEFT_OF && window_state.drag_and_drop_target {
-            pixel[0] = 128;
-            pixel[1] = 0;
-            pixel[2] = 0;
-        } else if window_state.active {
-            pixel[0] = 255;
-            pixel[1] = 255;
-            pixel[2] = 255;
-        } else {
-            pixel[0] = 128;
-            pixel[1] = 128;
-            pixel[2] = 128;
+    for y_idx in 0..physical_size.height.0 {
+        for x_idx in 0..physical_size.width.0 {
+            let offset = (y_idx as usize * data.stride as usize) + (x_idx as usize * BYTES_PER_PIXEL as usize);
+            let pixel = &mut canvas[offset..offset + 4];
+
+            let outer_x = f64::from(x_idx);
+            let outer_y = f64::from(y_idx);
+
+            if outer_x < p_left || outer_x >= outer_w - p_right || outer_y < p_top || outer_y >= outer_h - p_bottom {
+                pixel[0] = 0;
+                pixel[1] = 0;
+                pixel[2] = 0;
+                pixel[3] = 0;
+                continue;
+            }
+
+            let x = outer_x - p_left;
+            let y = outer_y - p_top;
+
+            let i = y.mul_add(w, x);
+
+            if between(
+                x,
+                DRAG_AND_DROP_LEFT_OF * scale,
+                DRAG_AND_DROP_LEFT_OF.mul_add(scale, line_thickness),
+            ) {
+                pixel[0] = 0;
+                pixel[1] = 0;
+                pixel[2] = 0;
+            } else if between(x, line_thickness,  line_thickness * 2.0)  // left border
+                || between(y, line_thickness,  line_thickness * 2.0)  // top border
+                || between(x, line_thickness.mul_add(-2.0, w), w - line_thickness)  // right border
+                || between(y, line_thickness.mul_add(-2.0, h), h - line_thickness)  // bottom border
+                || between(x, (i / h) - (line_thickness / 2.0), (i / h) + (line_thickness / 2.0))
+            {
+                pixel[0] = 0;
+                pixel[1] = 0;
+                pixel[2] = 255;
+            } else if x < DRAG_AND_DROP_LEFT_OF
+                && window_state.drag_and_drop_source
+                && between(y, drag_source_indicator_heigh, drag_source_indicator_heigh + line_thickness)
+            {
+                pixel[0] = 255;
+                pixel[1] = 0;
+                pixel[2] = 0;
+            } else if x < DRAG_AND_DROP_LEFT_OF && window_state.drag_and_drop_target {
+                pixel[0] = 128;
+                pixel[1] = 0;
+                pixel[2] = 0;
+            } else if window_state.active {
+                pixel[0] = 255;
+                pixel[1] = 255;
+                pixel[2] = 255;
+            } else {
+                pixel[0] = 128;
+                pixel[1] = 128;
+                pixel[2] = 128;
+            }
+            pixel[3] = 255;
         }
-        pixel[3] = 255;
     }
 }
 

--- a/native/desktop-linux/src/linux/application_state.rs
+++ b/native/desktop-linux/src/linux/application_state.rs
@@ -487,7 +487,9 @@ impl WindowHandler for ApplicationState {
                 self.callbacks.event_handler,
                 WindowConfigureEvent {
                     window_id: w.window_id,
-                    size: w.size.unwrap(),
+                    logical_geometry_size: w.logical_geometry_size.unwrap(),
+                    logical_buffer_size: w.logical_buffer_size().unwrap(),
+                    logical_insets: w.get_insets(),
                     active: configure.is_activated(),
                     maximized: configure.is_maximized(),
                     fullscreen: configure.is_fullscreen(),

--- a/native/desktop-linux/src/linux/data_transfer.rs
+++ b/native/desktop-linux/src/linux/data_transfer.rs
@@ -1,5 +1,6 @@
 use crate::linux::application::send_event;
 use crate::linux::geometry::{LogicalPixels, LogicalPoint};
+use crate::linux::window::SimpleWindow;
 use crate::linux::{
     application_api::{DataSource, DragAndDropAction, DragAndDropActions, DragAndDropQueryData},
     application_state::ApplicationState,
@@ -171,7 +172,16 @@ impl ApplicationState {
             warn!("Drop handler: couldn't find window for {surface:?}");
             return None;
         };
-        let mime_type_and_actions = self.get_drag_offer_actions(&drag_offer, (x, y).into(), window_id);
+        let insets = self
+            .window_id_to_surface_id
+            .get(&window_id)
+            .and_then(|id| self.windows.get(id).map(SimpleWindow::get_insets))
+            .unwrap_or_default();
+        let location_in_window = LogicalPoint {
+            x: LogicalPixels(x - f64::from(insets.left)),
+            y: LogicalPixels(y - f64::from(insets.top)),
+        };
+        let mime_type_and_actions = self.get_drag_offer_actions(&drag_offer, location_in_window, window_id);
         drag_offer.set_actions(mime_type_and_actions.supported_actions, mime_type_and_actions.preferred_action);
         drag_offer.accept_mime_type(drag_offer.serial, mime_type_and_actions.mime_type);
         Some(window_id)
@@ -229,9 +239,15 @@ impl DataDeviceHandler for ApplicationState {
             return;
         };
 
+        let insets = self
+            .window_id_to_surface_id
+            .get(&window_id)
+            .and_then(|id| self.windows.get(id).map(SimpleWindow::get_insets))
+            .unwrap_or_default();
+
         let location_in_window = LogicalPoint {
-            x: LogicalPixels(x),
-            y: LogicalPixels(y),
+            x: LogicalPixels(x - f64::from(insets.left)),
+            y: LogicalPixels(y - f64::from(insets.top)),
         };
 
         let mime_type_and_actions = self.get_drag_offer_actions(&drag_offer, location_in_window, window_id);

--- a/native/desktop-linux/src/linux/events.rs
+++ b/native/desktop-linux/src/linux/events.rs
@@ -1,7 +1,7 @@
 use crate::linux::{
     application_api::{DataSource, DragAndDropAction},
     desktop_settings_api::FfiDesktopSetting,
-    geometry::{LogicalPixels, LogicalPoint, LogicalSize, PhysicalSize},
+    geometry::{LogicalPixels, LogicalPoint, LogicalSideOffsets, LogicalSize, PhysicalSideOffsets, PhysicalSize},
 };
 use bitflag_attr::bitflag;
 use core::f64;
@@ -450,7 +450,11 @@ impl From<WindowClosedEvent> for Event<'_> {
 #[derive(Debug)]
 pub struct WindowConfigureEvent {
     pub window_id: WindowId,
-    pub size: LogicalSize,
+
+    pub logical_geometry_size: LogicalSize,
+    pub logical_buffer_size: LogicalSize,
+    pub logical_insets: LogicalSideOffsets,
+
     pub active: bool,
     pub maximized: bool,
     pub fullscreen: bool,
@@ -495,6 +499,7 @@ pub struct WindowDrawEvent {
     pub window_id: WindowId,
     pub software_draw_data: SoftwareDrawData,
     pub physical_size: PhysicalSize,
+    pub physical_insets: PhysicalSideOffsets,
     pub scale: f64,
 }
 

--- a/native/desktop-linux/src/linux/events.rs
+++ b/native/desktop-linux/src/linux/events.rs
@@ -498,7 +498,8 @@ pub struct SoftwareDrawData {
 pub struct WindowDrawEvent {
     pub window_id: WindowId,
     pub software_draw_data: SoftwareDrawData,
-    pub physical_size: PhysicalSize,
+    pub physical_geometry_size: PhysicalSize,
+    pub physical_buffer_size: PhysicalSize,
     pub physical_insets: PhysicalSideOffsets,
     pub scale: f64,
 }

--- a/native/desktop-linux/src/linux/geometry.rs
+++ b/native/desktop-linux/src/linux/geometry.rs
@@ -1,5 +1,5 @@
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct PhysicalPixels(pub i32);
 
 #[repr(transparent)]
@@ -15,7 +15,7 @@ impl LogicalPixels {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct PhysicalSize {
     pub width: PhysicalPixels,
     pub height: PhysicalPixels,
@@ -67,4 +67,34 @@ pub struct LogicalRect {
     pub y: i32,
     pub width: i32,
     pub height: i32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LogicalSideOffsets {
+    pub top: u32,
+    pub left: u32,
+    pub bottom: u32,
+    pub right: u32,
+}
+
+impl LogicalSideOffsets {
+    #[must_use]
+    pub fn to_physical(&self, scale: f64) -> PhysicalSideOffsets {
+        PhysicalSideOffsets {
+            top: to_physical_value(self.top, scale),
+            left: to_physical_value(self.left, scale),
+            bottom: to_physical_value(self.bottom, scale),
+            right: to_physical_value(self.right, scale),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PhysicalSideOffsets {
+    pub top: PhysicalPixels,
+    pub left: PhysicalPixels,
+    pub bottom: PhysicalPixels,
+    pub right: PhysicalPixels,
 }

--- a/native/desktop-linux/src/linux/mouse.rs
+++ b/native/desktop-linux/src/linux/mouse.rs
@@ -52,6 +52,12 @@ impl PointerHandler for ApplicationState {
             };
             let scale = window.current_scale;
             let window_id = window.window_id;
+            let insets = window.get_insets();
+
+            let location_in_window = LogicalPoint {
+                x: LogicalPixels(event.position.0 - f64::from(insets.left)),
+                y: LogicalPixels(event.position.1 - f64::from(insets.top)),
+            };
 
             let res = match event.kind {
                 PointerEventKind::Enter { .. } => {
@@ -59,7 +65,7 @@ impl PointerHandler for ApplicationState {
                     window.set_cursor = true;
                     let res = self.send_event(MouseEnteredEvent {
                         window_id,
-                        location_in_window: LogicalPoint::from(event.position),
+                        location_in_window,
                     });
                     if let Some(themed_pointer) = self.themed_pointer.take() {
                         let pointer_surface = themed_pointer.surface();
@@ -86,12 +92,12 @@ impl PointerHandler for ApplicationState {
                     window.num_pointer_buttons_down = 0;
                     self.send_event(MouseExitedEvent {
                         window_id,
-                        location_in_window: LogicalPoint::from(event.position),
+                        location_in_window,
                     })
                 }
                 PointerEventKind::Motion { time } => self.send_event(MouseMovedEvent {
                     window_id,
-                    location_in_window: LogicalPoint::from(event.position),
+                    location_in_window,
                     timestamp: Timestamp(time),
                 }),
                 PointerEventKind::Press { button, serial, time } => {
@@ -102,7 +108,7 @@ impl PointerHandler for ApplicationState {
                     self.send_event(MouseDownEvent {
                         window_id,
                         button: MouseButton(button),
-                        location_in_window: LogicalPoint::from(event.position),
+                        location_in_window,
                         timestamp: Timestamp(time),
                     })
                 }
@@ -114,7 +120,7 @@ impl PointerHandler for ApplicationState {
                     self.send_event(MouseUpEvent {
                         window_id,
                         button: MouseButton(button),
-                        location_in_window: LogicalPoint::from(event.position),
+                        location_in_window,
                         timestamp: Timestamp(time),
                     })
                 }
@@ -127,7 +133,7 @@ impl PointerHandler for ApplicationState {
                     debug!("wl_pointer vertical={vertical:?}");
                     self.send_event(ScrollWheelEvent {
                         window_id,
-                        location_in_window: LogicalPoint::from(event.position),
+                        location_in_window,
                         timestamp: Timestamp(time),
                         horizontal_scroll: ScrollData::from(horizontal),
                         vertical_scroll: ScrollData::from(vertical),

--- a/native/desktop-linux/src/linux/window.rs
+++ b/native/desktop-linux/src/linux/window.rs
@@ -258,23 +258,25 @@ impl SimpleWindow {
         self.update_pointer(conn, themed_pointer);
         let surface = self.window.wl_surface();
 
-        let geometry_size = self.logical_geometry_size.unwrap();
-        let total_logical_size = self.total_logical_size(geometry_size);
-        let physical_size = total_logical_size.to_physical(self.current_scale);
+        let logical_geometry_size = self.logical_geometry_size.unwrap();
+        let physical_geometry_size = logical_geometry_size.to_physical(self.current_scale);
+        let total_logical_size = self.total_logical_size(logical_geometry_size);
+        let physical_buffer_size = total_logical_size.to_physical(self.current_scale);
         let physical_insets = self.insets.to_physical(self.current_scale);
 
         let do_draw = |software_draw_data: SoftwareDrawData| {
             let did_draw = callback(WindowDrawEvent {
                 window_id: self.window_id,
                 software_draw_data,
-                physical_size,
+                physical_geometry_size,
+                physical_buffer_size,
                 physical_insets,
                 scale: self.current_scale,
             });
 
             if did_draw {
                 // Damage the entire window
-                surface.damage_buffer(0, 0, physical_size.width.0, physical_size.height.0);
+                surface.damage_buffer(0, 0, physical_buffer_size.width.0, physical_buffer_size.height.0);
             }
 
             // Request our next frame
@@ -283,7 +285,7 @@ impl SimpleWindow {
         };
 
         if let Some(r) = &mut self.rendering_data {
-            r.draw(surface, physical_size, do_draw);
+            r.draw(surface, physical_buffer_size, do_draw);
         } else {
             warn!("Rendering data not initialized in draw");
         }

--- a/native/desktop-linux/src/linux/window.rs
+++ b/native/desktop-linux/src/linux/window.rs
@@ -10,7 +10,10 @@ use smithay_client_toolkit::{
     seat::pointer::{CursorIcon, ThemedPointer},
     shell::{
         WaylandSurface,
-        xdg::window::{DecorationMode, Window, WindowConfigure, WindowDecorations},
+        xdg::{
+            XdgSurface,
+            window::{DecorationMode, Window, WindowConfigure, WindowDecorations},
+        },
     },
     shm::Shm,
 };
@@ -19,7 +22,7 @@ use crate::linux::{
     application_api::RenderingMode,
     application_state::{ApplicationState, EglInstance},
     events::{SoftwareDrawData, WindowDecorationMode, WindowDrawEvent, WindowId},
-    geometry::{LogicalPoint, LogicalSize, PhysicalSize},
+    geometry::{LogicalPixels, LogicalPoint, LogicalSideOffsets, LogicalSize, PhysicalSize},
     pointer_shapes_api::PointerShape,
     rendering_egl::EglRendering,
     rendering_software::SoftwareRendering,
@@ -58,8 +61,9 @@ pub struct SimpleWindow {
     pub window_id: WindowId,
     pub app_id: String,
     pub close: bool,
-    pub size: Option<LogicalSize>,
+    pub logical_geometry_size: Option<LogicalSize>,
     viewport: Option<WpViewport>,
+    insets: LogicalSideOffsets,
     pub window: Window,
     pub set_cursor: bool,
     decorations_cursor: Option<CursorIcon>,
@@ -126,8 +130,9 @@ impl SimpleWindow {
             window_id,
             app_id,
             close: false,
-            size,
+            logical_geometry_size: size,
             viewport,
+            insets: params.insets,
             window,
             set_cursor: false,
             decorations_cursor: Some(CursorIcon::Default),
@@ -161,29 +166,36 @@ impl SimpleWindow {
             .new_size
             .0
             .map(std::num::NonZero::get)
-            .or_else(|| self.size.map(|s| s.width))
+            .or_else(|| self.logical_geometry_size.map(|s| s.width))
             .or_else(|| configure.suggested_bounds.map(|(w, _h)| w))
             .unwrap_or(DEFAULT_WIDTH);
         let height = configure
             .new_size
             .1
             .map(std::num::NonZero::get)
-            .or_else(|| self.size.map(|s| s.height))
+            .or_else(|| self.logical_geometry_size.map(|s| s.height))
             .or_else(|| configure.suggested_bounds.map(|(_w, h)| h))
             .unwrap_or(DEFAULT_HEIGHT);
-        let size = LogicalSize { width, height };
-        self.size = Some(size);
 
-        // window.set_window_geometry(0, 0, width, height);
+        let geometry_size = LogicalSize { width, height };
+        self.logical_geometry_size = Some(geometry_size);
+
+        self.window.xdg_surface().set_window_geometry(
+            self.insets.left as i32,
+            self.insets.top as i32,
+            geometry_size.width as i32,
+            geometry_size.height as i32,
+        );
         // TODO: wl_surface::set_opaque_region?
 
-        let physical_size = size.to_physical(self.current_scale);
+        let total_logical_size = self.total_logical_size(geometry_size);
+        let physical_size = total_logical_size.to_physical(self.current_scale);
         debug!(
-            "SimpleWindow::configure for {:?}: size={size:?}, physical_size={physical_size:?}",
+            "SimpleWindow::configure for {:?}: geometry_size={geometry_size:?}, total_logical_size={total_logical_size:?}, physical_size={physical_size:?}",
             self.window_id
         );
 
-        self.on_resize(size, physical_size, shm);
+        self.on_resize(total_logical_size, physical_size, shm);
 
         let is_first_configure = self.rendering_data.is_none();
         if is_first_configure {
@@ -246,13 +258,17 @@ impl SimpleWindow {
         self.update_pointer(conn, themed_pointer);
         let surface = self.window.wl_surface();
 
-        let physical_size = self.size.unwrap().to_physical(self.current_scale);
+        let geometry_size = self.logical_geometry_size.unwrap();
+        let total_logical_size = self.total_logical_size(geometry_size);
+        let physical_size = total_logical_size.to_physical(self.current_scale);
+        let physical_insets = self.insets.to_physical(self.current_scale);
 
         let do_draw = |software_draw_data: SoftwareDrawData| {
             let did_draw = callback(WindowDrawEvent {
                 window_id: self.window_id,
                 software_draw_data,
                 physical_size,
+                physical_insets,
                 scale: self.current_scale,
             });
 
@@ -305,8 +321,9 @@ impl SimpleWindow {
         debug!("scale_changed: {new_scale} for {:?}", self.window_id);
         self.current_scale = new_scale;
 
-        if let Some(size) = self.size {
-            self.on_resize(size, size.to_physical(self.current_scale), shm);
+        if let Some(geometry_size) = self.logical_geometry_size {
+            let total_logical = self.total_logical_size(geometry_size);
+            self.on_resize(total_logical, total_logical.to_physical(self.current_scale), shm);
         }
     }
 
@@ -327,7 +344,11 @@ impl SimpleWindow {
     }
 
     pub fn show_menu(&self, position: LogicalPoint, seat: &WlSeat, serial: u32) {
-        self.window.show_window_menu(seat, serial, (position.x.round(), position.y.round()));
+        let adjusted = LogicalPoint {
+            x: LogicalPixels(position.x.0 + f64::from(self.insets.left)),
+            y: LogicalPixels(position.y.0 + f64::from(self.insets.top)),
+        };
+        self.window.show_window_menu(seat, serial, (adjusted.x.round(), adjusted.y.round()));
     }
 
     pub fn set_max_size(&self, max_size: LogicalSize) {
@@ -348,5 +369,24 @@ impl SimpleWindow {
         };
         self.window.set_min_size(opt_min_size);
         self.window.commit();
+    }
+
+    pub const fn get_insets(&self) -> LogicalSideOffsets {
+        self.insets
+    }
+
+    const fn total_logical_size(&self, geometry_size: LogicalSize) -> LogicalSize {
+        LogicalSize {
+            width: geometry_size.width + self.insets.left + self.insets.right,
+            height: geometry_size.height + self.insets.top + self.insets.bottom,
+        }
+    }
+
+    pub fn logical_buffer_size(&self) -> Option<LogicalSize> {
+        self.logical_geometry_size.map(|geometry| self.total_logical_size(geometry))
+    }
+
+    pub fn physical_buffer_size(&self) -> Option<PhysicalSize> {
+        self.logical_buffer_size().map(|logical| logical.to_physical(self.current_scale))
     }
 }

--- a/native/desktop-linux/src/linux/window_api.rs
+++ b/native/desktop-linux/src/linux/window_api.rs
@@ -5,7 +5,7 @@ use crate::linux::{
     data_transfer::MimeTypes,
     events::{RequestId, WindowDecorationMode, WindowId},
     file_dialog_api::{CommonFileDialogParams, OpenFileDialogParams, SaveFileDialogParams},
-    geometry::{LogicalPoint, LogicalSize},
+    geometry::{LogicalPoint, LogicalSideOffsets, LogicalSize, PhysicalSize},
     pointer_shapes_api::PointerShape,
     window_resize_edge_api::WindowResizeEdge,
 };
@@ -54,6 +54,8 @@ pub struct WindowParams<'a> {
 
     pub min_size: LogicalSize,
 
+    pub insets: LogicalSideOffsets,
+
     pub title: BorrowedUtf8<'a>,
 
     /// See <https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id>
@@ -91,8 +93,27 @@ pub extern "C" fn window_set_pointer_shape(mut app_ptr: AppPtr, window_id: Windo
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn window_get_size(app_ptr: AppPtr, window_id: WindowId) -> LogicalSize {
-    with_window(&app_ptr, window_id, "window_get_size", |w| Ok(w.size)).unwrap_or_default()
+pub extern "C" fn window_get_logical_geometry_size(app_ptr: AppPtr, window_id: WindowId) -> LogicalSize {
+    with_window(&app_ptr, window_id, "window_get_logical_geometry_size", |w| {
+        Ok(w.logical_geometry_size)
+    })
+    .unwrap_or_default()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn window_get_logical_buffer_size(app_ptr: AppPtr, window_id: WindowId) -> LogicalSize {
+    with_window(&app_ptr, window_id, "window_get_logical_buffer_size", |w| {
+        Ok(w.logical_buffer_size())
+    })
+    .unwrap_or_default()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn window_get_physical_buffer_size(app_ptr: AppPtr, window_id: WindowId) -> PhysicalSize {
+    with_window(&app_ptr, window_id, "window_get_physical_buffer_size", |w| {
+        Ok(w.physical_buffer_size())
+    })
+    .unwrap_or_default()
 }
 
 #[unsafe(no_mangle)]

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoCustomTitlebarLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoCustomTitlebarLinux.kt
@@ -57,7 +57,7 @@ internal class SkikoCustomTitlebarLinux(
     }
 
     fun configure(event: Event.WindowConfigure, layout: TitlebarLayout) {
-        size = LogicalSize(width = event.size.width, height = CUSTOM_TITLEBAR_HEIGHT)
+        size = LogicalSize(width = event.logicalGeometrySize.width, height = CUSTOM_TITLEBAR_HEIGHT)
         setLayout(layout)
     }
 

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoSampleLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoSampleLinux.kt
@@ -23,6 +23,7 @@ import org.jetbrains.desktop.linux.LogLevel
 import org.jetbrains.desktop.linux.Logger
 import org.jetbrains.desktop.linux.LogicalPoint
 import org.jetbrains.desktop.linux.LogicalRect
+import org.jetbrains.desktop.linux.LogicalSideOffsets
 import org.jetbrains.desktop.linux.LogicalSize
 import org.jetbrains.desktop.linux.MouseButton
 import org.jetbrains.desktop.linux.PhysicalPoint
@@ -778,12 +779,14 @@ internal class WindowState {
     var fullscreen: Boolean = false
     var capabilities: WindowCapabilities? = null
     var pointerShape: PointerShape = PointerShape.Default
+    var insets: LogicalSideOffsets = LogicalSideOffsets.Zero
 
     fun configure(event: Event.WindowConfigure) {
         active = event.active
         maximized = event.maximized
         fullscreen = event.fullscreen
         capabilities = event.capabilities
+        insets = event.logicalInsets
     }
 }
 
@@ -967,7 +970,7 @@ private class ContentArea(
 
 private class CustomBorders {
     companion object {
-        const val BORDER_SIZE = 5
+        const val BORDER_SIZE = 10
 
         fun edgeToPointerShape(edge: WindowResizeEdge): PointerShape {
             return when (edge) {
@@ -986,46 +989,21 @@ private class CustomBorders {
     private var rectangles = ArrayList<Pair<LogicalRect, WindowResizeEdge>>()
 
     fun configure(event: Event.WindowConfigure) {
-        rectangles.clear()
-        rectangles.add(Pair(LogicalRect(x = 0, y = 0, width = BORDER_SIZE, height = BORDER_SIZE), WindowResizeEdge.TopLeft))
-        rectangles.add(
-            Pair(
-                LogicalRect(x = event.size.width - BORDER_SIZE, y = 0, width = BORDER_SIZE, height = BORDER_SIZE),
-                WindowResizeEdge.TopRight,
-            ),
-        )
-        rectangles.add(
-            Pair(
-                LogicalRect(x = 0, y = event.size.height - BORDER_SIZE, width = BORDER_SIZE, height = BORDER_SIZE),
-                WindowResizeEdge.BottomLeft,
-            ),
-        )
-        rectangles.add(
-            Pair(
-                LogicalRect(
-                    x = event.size.width - BORDER_SIZE,
-                    y = event.size.height - BORDER_SIZE,
-                    width = BORDER_SIZE,
-                    height = BORDER_SIZE,
-                ),
-                WindowResizeEdge.BottomRight,
-            ),
-        )
+        val insets = event.logicalInsets
+        val geometryWidth = event.logicalGeometrySize.width
+        val geometryHeight = event.logicalGeometrySize.height
 
-        rectangles.add(Pair(LogicalRect(x = 0, y = 0, width = BORDER_SIZE, height = event.size.height), WindowResizeEdge.Left))
-        rectangles.add(
-            Pair(
-                LogicalRect(x = event.size.width - BORDER_SIZE, y = 0, width = BORDER_SIZE, height = event.size.height),
-                WindowResizeEdge.Right,
-            ),
-        )
-        rectangles.add(Pair(LogicalRect(x = 0, y = 0, width = event.size.width, height = BORDER_SIZE), WindowResizeEdge.Top))
-        rectangles.add(
-            Pair(
-                LogicalRect(x = 0, y = event.size.height - BORDER_SIZE, width = event.size.width, height = BORDER_SIZE),
-                WindowResizeEdge.Bottom,
-            ),
-        )
+        rectangles.clear()
+
+        rectangles.add(Pair(LogicalRect(-insets.left, -insets.top, insets.left, insets.top), WindowResizeEdge.TopLeft))
+        rectangles.add(Pair(LogicalRect(geometryWidth, -insets.top, insets.right, insets.top), WindowResizeEdge.TopRight))
+        rectangles.add(Pair(LogicalRect(-insets.left, geometryHeight, insets.left, insets.bottom), WindowResizeEdge.BottomLeft))
+        rectangles.add(Pair(LogicalRect(geometryWidth, geometryHeight, insets.right, insets.bottom), WindowResizeEdge.BottomRight))
+
+        rectangles.add(Pair(LogicalRect(-insets.left, 0, insets.left, geometryHeight), WindowResizeEdge.Left))
+        rectangles.add(Pair(LogicalRect(geometryWidth, 0, insets.right, geometryHeight), WindowResizeEdge.Right))
+        rectangles.add(Pair(LogicalRect(0, -insets.top, geometryWidth, insets.top), WindowResizeEdge.Top))
+        rectangles.add(Pair(LogicalRect(0, geometryHeight, geometryWidth, insets.bottom), WindowResizeEdge.Bottom))
     }
 
     fun toEdge(locationInWindow: LogicalPoint): WindowResizeEdge? {
@@ -1100,7 +1078,7 @@ private class WindowContainer(
                 layoutLeft = filterUnsupportedButtons(xdgDesktopSettings.titlebarLayout.layoutLeft, event.capabilities),
                 layoutRight = filterUnsupportedButtons(xdgDesktopSettings.titlebarLayout.layoutRight, event.capabilities),
             )
-            val titlebarSize = LogicalSize(width = event.size.width, height = SkikoCustomTitlebarLinux.CUSTOM_TITLEBAR_HEIGHT)
+            val titlebarSize = LogicalSize(width = event.logicalGeometrySize.width, height = SkikoCustomTitlebarLinux.CUSTOM_TITLEBAR_HEIGHT)
             val titlebar = customTitlebar ?: SkikoCustomTitlebarLinux(
                 size = titlebarSize,
                 titlebarLayout,
@@ -1113,11 +1091,11 @@ private class WindowContainer(
             customBorders.configure(event)
             contentArea.origin = LogicalPoint(x = 0.0, y = titlebar.size.height.toDouble())
             contentArea.size =
-                LogicalSize(width = event.size.width, height = event.size.height - titlebar.size.height)
+                LogicalSize(width = event.logicalGeometrySize.width, height = event.logicalGeometrySize.height - titlebar.size.height)
         } else {
             customTitlebar = null
             contentArea.origin = LogicalPoint(x = 0.0, y = 0.0)
-            contentArea.size = event.size
+            contentArea.size = event.logicalGeometrySize
         }
     }
 
@@ -1431,6 +1409,7 @@ private class ApplicationState(private val app: Application) : AutoCloseable {
             windowId = windowId,
             size = LogicalSize(width = 640, height = 480),
             minSize = LogicalSize(320, 240),
+            insets = LogicalSideOffsets(CustomBorders.BORDER_SIZE),
             title = "Window $windowId",
             appId = "org.jetbrains.desktop.linux.skikoSample1",
             preferClientSideDecoration = useCustomTitlebar,

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoSampleLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoSampleLinux.kt
@@ -1078,7 +1078,8 @@ private class WindowContainer(
                 layoutLeft = filterUnsupportedButtons(xdgDesktopSettings.titlebarLayout.layoutLeft, event.capabilities),
                 layoutRight = filterUnsupportedButtons(xdgDesktopSettings.titlebarLayout.layoutRight, event.capabilities),
             )
-            val titlebarSize = LogicalSize(width = event.logicalGeometrySize.width, height = SkikoCustomTitlebarLinux.CUSTOM_TITLEBAR_HEIGHT)
+            val titlebarSize =
+                LogicalSize(width = event.logicalGeometrySize.width, height = SkikoCustomTitlebarLinux.CUSTOM_TITLEBAR_HEIGHT)
             val titlebar = customTitlebar ?: SkikoCustomTitlebarLinux(
                 size = titlebarSize,
                 titlebarLayout,

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
@@ -74,10 +74,6 @@ abstract class SkikoWindowLinux(
     }
 
     fun performDrawing(event: Event.WindowDraw): Boolean {
-        val contentSize = PhysicalSize(
-            width = event.physicalSize.width - event.physicalInsets.left - event.physicalInsets.right,
-            height = event.physicalSize.height - event.physicalInsets.top - event.physicalInsets.bottom,
-        )
         val draw = { surface: Surface ->
             val canvas = surface.canvas
 
@@ -87,14 +83,14 @@ abstract class SkikoWindowLinux(
                 Rect(
                     event.physicalInsets.left.toFloat(),
                     event.physicalInsets.top.toFloat(),
-                    (event.physicalInsets.left + contentSize.width).toFloat(),
-                    (event.physicalInsets.top + contentSize.height).toFloat(),
+                    (event.physicalInsets.left + event.physicalGeometrySize.width).toFloat(),
+                    (event.physicalInsets.top + event.physicalGeometrySize.height).toFloat(),
                 )
             )
             canvas.translate(event.physicalInsets.left.toFloat(), event.physicalInsets.top.toFloat())
 
             val time = creationTime.elapsedNow().inWholeMilliseconds
-            surface.canvas.draw(contentSize, event.scale, time)
+            surface.canvas.draw(event.physicalGeometrySize, event.scale, time)
 
             canvas.restore()
             surface.flushAndSubmit()
@@ -102,8 +98,8 @@ abstract class SkikoWindowLinux(
             true
         }
         return event.softwareDrawData?.let { softwareDrawData ->
-            performSoftwareDrawing(event.physicalSize, softwareDrawData, draw)
-        } ?: performOpenGlDrawing(event.physicalSize, directContext, draw)
+            performSoftwareDrawing(event.physicalBufferSize, softwareDrawData, draw)
+        } ?: performOpenGlDrawing(event.physicalBufferSize, directContext, draw)
     }
 
     abstract fun Canvas.draw(size: PhysicalSize, scale: Double, time: Long)

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
@@ -15,6 +15,7 @@ import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
@@ -27,7 +28,7 @@ internal fun performSoftwareDrawing(size: PhysicalSize, softwareDrawData: Softwa
             width = size.width,
             height = size.height,
             colorType = ColorType.BGRA_8888,
-            alphaType = ColorAlphaType.OPAQUE,
+            alphaType = ColorAlphaType.PREMUL,
             colorSpace = ColorSpace.sRGB,
         ),
         pixelsPtr = softwareDrawData.canvas,
@@ -73,15 +74,36 @@ abstract class SkikoWindowLinux(
     }
 
     fun performDrawing(event: Event.WindowDraw): Boolean {
+        val contentSize = PhysicalSize(
+            width = event.physicalSize.width - event.physicalInsets.left - event.physicalInsets.right,
+            height = event.physicalSize.height - event.physicalInsets.top - event.physicalInsets.bottom,
+        )
         val draw = { surface: Surface ->
+            val canvas = surface.canvas
+
+            canvas.clear(0x00000000)
+            canvas.save()
+            canvas.clipRect(
+                Rect(
+                    event.physicalInsets.left.toFloat(),
+                    event.physicalInsets.top.toFloat(),
+                    (event.physicalInsets.left + contentSize.width).toFloat(),
+                    (event.physicalInsets.top + contentSize.height).toFloat(),
+                )
+            )
+            canvas.translate(event.physicalInsets.left.toFloat(), event.physicalInsets.top.toFloat())
+
             val time = creationTime.elapsedNow().inWholeMilliseconds
-            surface.canvas.draw(event.size, event.scale, time)
+            surface.canvas.draw(contentSize, event.scale, time)
+
+            canvas.restore()
             surface.flushAndSubmit()
+
             true
         }
         return event.softwareDrawData?.let { softwareDrawData ->
-            performSoftwareDrawing(event.size, softwareDrawData, draw)
-        } ?: performOpenGlDrawing(event.size, directContext, draw)
+            performSoftwareDrawing(event.physicalSize, softwareDrawData, draw)
+        } ?: performOpenGlDrawing(event.physicalSize, directContext, draw)
     }
 
     abstract fun Canvas.draw(size: PhysicalSize, scale: Double, time: Long)

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/linux/SkikoWindowLinux.kt
@@ -85,7 +85,7 @@ abstract class SkikoWindowLinux(
                     event.physicalInsets.top.toFloat(),
                     (event.physicalInsets.left + event.physicalGeometrySize.width).toFloat(),
                     (event.physicalInsets.top + event.physicalGeometrySize.height).toFloat(),
-                )
+                ),
             )
             canvas.translate(event.physicalInsets.left.toFloat(), event.physicalInsets.top.toFloat())
 


### PR DESCRIPTION
Wayland has the ability to set the window geometry to that of a sub-region of the actual buffer.
This is primarily used for implementing resize handles that extend past the window content and also for rendering window shadows.
GTK does this already behind the scenes, this PR brings that functionality to the Wayland implementation.

<details>
  <summary>old native sample</summary>

https://github.com/user-attachments/assets/13c133ea-9769-4af8-b1df-470d843fee9e

</details>

<details>
  <summary>new native sample</summary>

https://github.com/user-attachments/assets/1ac925f9-ad8b-4961-a557-01d544d5ed3f

</details>


<details>
  <summary>old skiko sample</summary>

https://github.com/user-attachments/assets/2e648b20-edf8-47bc-969d-dd5da7157713

</details>


<details>
  <summary>new skiko sample</summary>

https://github.com/user-attachments/assets/a68c5324-9b1e-4856-a492-713f30d5d8fc

</details>


The events may not be completely optimal. Depends on how much work you want to do before or after the ffi boundary / how much you want to send over the boundary.

Also in the test cases I didn't change how the rendering is done, that might be something to do. LMK of you want that, I'm sure I can work it out.
