### PR TITLE
feat(macos): support mouse back/forward buttons sent as swipe gestures

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Event.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Event.kt
@@ -5,6 +5,7 @@ import org.jetbrains.desktop.macos.generated.NativeApplicationOpenUrlsEvent
 import org.jetbrains.desktop.macos.generated.NativeEvent
 import org.jetbrains.desktop.macos.generated.NativeKeyDownEvent
 import org.jetbrains.desktop.macos.generated.NativeKeyUpEvent
+import org.jetbrains.desktop.macos.generated.NativeMagnifyEvent
 import org.jetbrains.desktop.macos.generated.NativeModifiersChangedEvent
 import org.jetbrains.desktop.macos.generated.NativeMouseDownEvent
 import org.jetbrains.desktop.macos.generated.NativeMouseDraggedEvent
@@ -12,7 +13,10 @@ import org.jetbrains.desktop.macos.generated.NativeMouseEnteredEvent
 import org.jetbrains.desktop.macos.generated.NativeMouseExitedEvent
 import org.jetbrains.desktop.macos.generated.NativeMouseMovedEvent
 import org.jetbrains.desktop.macos.generated.NativeMouseUpEvent
+import org.jetbrains.desktop.macos.generated.NativeRotateEvent
 import org.jetbrains.desktop.macos.generated.NativeScrollWheelEvent
+import org.jetbrains.desktop.macos.generated.NativeSmartMagnifyEvent
+import org.jetbrains.desktop.macos.generated.NativeSwipeEvent
 import org.jetbrains.desktop.macos.generated.NativeWindowChangedOcclusionStateEvent
 import org.jetbrains.desktop.macos.generated.NativeWindowCloseRequestEvent
 import org.jetbrains.desktop.macos.generated.NativeWindowFocusChangeEvent
@@ -253,6 +257,67 @@ public sealed class Event {
     ) : Event(),
         WindowEvent
 
+    /**
+     * Pinch-to-zoom trackpad gesture (`magnifyWithEvent:`).
+     *
+     * @param magnification the incremental magnification change for this event, to be accumulated over
+     * the gesture. A full pinch sums to roughly ±1.0.
+     * Apple doc: https://developer.apple.com/documentation/appkit/nsevent/magnification?language=objc
+     */
+    public data class Magnify(
+        override val windowId: WindowId,
+        val magnification: Double,
+        val phase: EventPhase,
+        val locationInWindow: LogicalPoint,
+        val timestamp: Timestamp,
+    ) : Event(),
+        WindowEvent
+
+    /**
+     * Two-finger rotation trackpad gesture (`rotateWithEvent:`).
+     *
+     * @param rotation the incremental rotation change in degrees for this event, to be accumulated over
+     * the gesture. Counter-clockwise rotation is positive.
+     * Apple doc: https://developer.apple.com/documentation/appkit/nsevent/rotation?language=objc
+     */
+    public data class Rotate(
+        override val windowId: WindowId,
+        val rotation: Double,
+        val phase: EventPhase,
+        val locationInWindow: LogicalPoint,
+        val timestamp: Timestamp,
+    ) : Event(),
+        WindowEvent
+
+    /**
+     * Two-finger double-tap "smart zoom" trackpad gesture (`smartMagnifyWithEvent:`).
+     * Carries no magnitude; the consumer decides how to toggle zoom.
+     * Apple doc: https://developer.apple.com/documentation/appkit/nsresponder/smartmagnify(with:)?language=objc
+     */
+    public data class SmartMagnify(
+        override val windowId: WindowId,
+        val locationInWindow: LogicalPoint,
+        val timestamp: Timestamp,
+    ) : Event(),
+        WindowEvent
+
+    /**
+     * Trackpad swipe gesture (`swipeWithEvent:`).
+     *
+     * @param deltaX horizontal direction of the swipe, typically -1, 0, or 1 (positive is a swipe to the left).
+     * @param deltaY vertical direction of the swipe, typically -1, 0, or 1 (positive is a swipe up).
+     * Apple doc: https://developer.apple.com/documentation/appkit/nsresponder/swipe(with:)?language=objc
+     */
+    public data class Swipe(
+        override val windowId: WindowId,
+        val deltaX: Double,
+        val deltaY: Double,
+        val phase: EventPhase,
+        val locationInWindow: LogicalPoint,
+        val timestamp: Timestamp,
+    ) : Event(),
+        WindowEvent
+
     public data class WindowScreenChange(
         override val windowId: WindowId,
         val newScreenId: ScreenId,
@@ -408,7 +473,47 @@ internal fun Event.Companion.fromNative(s: MemorySegment): Event {
                 locationInWindow = LogicalPoint.fromNative(NativeScrollWheelEvent.location_in_window(nativeEvent)),
                 timestamp = Timestamp(NativeScrollWheelEvent.timestamp(nativeEvent)),
             )
-        } desktop_macos_h.NativeEvent_WindowScreenChange() -> {
+        }
+        desktop_macos_h.NativeEvent_Magnify() -> {
+            val nativeEvent = NativeEvent.magnify(s)
+            Event.Magnify(
+                windowId = NativeMagnifyEvent.window_id(nativeEvent),
+                magnification = NativeMagnifyEvent.magnification(nativeEvent),
+                phase = EventPhase.fromNative(NativeMagnifyEvent.phase(nativeEvent)),
+                locationInWindow = LogicalPoint.fromNative(NativeMagnifyEvent.location_in_window(nativeEvent)),
+                timestamp = Timestamp(NativeMagnifyEvent.timestamp(nativeEvent)),
+            )
+        }
+        desktop_macos_h.NativeEvent_Rotate() -> {
+            val nativeEvent = NativeEvent.rotate(s)
+            Event.Rotate(
+                windowId = NativeRotateEvent.window_id(nativeEvent),
+                rotation = NativeRotateEvent.rotation(nativeEvent),
+                phase = EventPhase.fromNative(NativeRotateEvent.phase(nativeEvent)),
+                locationInWindow = LogicalPoint.fromNative(NativeRotateEvent.location_in_window(nativeEvent)),
+                timestamp = Timestamp(NativeRotateEvent.timestamp(nativeEvent)),
+            )
+        }
+        desktop_macos_h.NativeEvent_SmartMagnify() -> {
+            val nativeEvent = NativeEvent.smart_magnify(s)
+            Event.SmartMagnify(
+                windowId = NativeSmartMagnifyEvent.window_id(nativeEvent),
+                locationInWindow = LogicalPoint.fromNative(NativeSmartMagnifyEvent.location_in_window(nativeEvent)),
+                timestamp = Timestamp(NativeSmartMagnifyEvent.timestamp(nativeEvent)),
+            )
+        }
+        desktop_macos_h.NativeEvent_Swipe() -> {
+            val nativeEvent = NativeEvent.swipe(s)
+            Event.Swipe(
+                windowId = NativeSwipeEvent.window_id(nativeEvent),
+                deltaX = NativeSwipeEvent.delta_x(nativeEvent),
+                deltaY = NativeSwipeEvent.delta_y(nativeEvent),
+                phase = EventPhase.fromNative(NativeSwipeEvent.phase(nativeEvent)),
+                locationInWindow = LogicalPoint.fromNative(NativeSwipeEvent.location_in_window(nativeEvent)),
+                timestamp = Timestamp(NativeSwipeEvent.timestamp(nativeEvent)),
+            )
+        }
+        desktop_macos_h.NativeEvent_WindowScreenChange() -> {
             val nativeEvent = NativeEvent.window_screen_change(s)
             Event.WindowScreenChange(
                 windowId = NativeWindowScreenChangeEvent.window_id(nativeEvent),

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/EventPhase.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/EventPhase.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.desktop.macos
+
+import org.jetbrains.desktop.macos.generated.desktop_macos_h
+
+/**
+ * Phase of a continuous gesture (pinch, rotate, swipe).
+ * Apple doc: https://developer.apple.com/documentation/appkit/nsevent/phase?language=objc
+ */
+public enum class EventPhase {
+    None,
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+    ;
+
+    internal companion object {
+        internal fun fromNative(value: Int): EventPhase {
+            return when (value) {
+                desktop_macos_h.NativeEventPhase_None() -> None
+                desktop_macos_h.NativeEventPhase_Began() -> Began
+                desktop_macos_h.NativeEventPhase_Stationary() -> Stationary
+                desktop_macos_h.NativeEventPhase_Changed() -> Changed
+                desktop_macos_h.NativeEventPhase_Ended() -> Ended
+                desktop_macos_h.NativeEventPhase_Cancelled() -> Cancelled
+                desktop_macos_h.NativeEventPhase_MayBegin() -> MayBegin
+                else -> throw Error("Unexpected variant $value")
+            }
+        }
+    }
+}

--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Mouse.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Mouse.kt
@@ -6,6 +6,8 @@ public value class MouseButton internal constructor(public val value: Int) {
         public val LEFT: MouseButton = MouseButton(0)
         public val RIGHT: MouseButton = MouseButton(1)
         public val MIDDLE: MouseButton = MouseButton(2)
+        public val BACK: MouseButton = MouseButton(3)
+        public val FORWARD: MouseButton = MouseButton(4)
     }
 
     override fun toString(): String {
@@ -13,6 +15,8 @@ public value class MouseButton internal constructor(public val value: Int) {
             LEFT -> "MouseButton.LEFT"
             RIGHT -> "MouseButton.RIGHT"
             MIDDLE -> "MouseButton.MIDDLE"
+            BACK -> "MouseButton.BACK"
+            FORWARD -> "MouseButton.FORWARD"
             else -> "MouseButton.Other($value)"
         }
     }

--- a/native/desktop-macos/src/macos/events.rs
+++ b/native/desktop-macos/src/macos/events.rs
@@ -128,6 +128,89 @@ pub struct ScrollWheelEvent {
     pub timestamp: Timestamp,
 }
 
+/// Phase of a continuous gesture (pinch, rotate, swipe), derived from `NSEvent.phase`.
+/// Apple doc: <https://developer.apple.com/documentation/appkit/nsevent/phase?language=objc>
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum EventPhase {
+    None,
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+}
+
+impl EventPhase {
+    fn from_ns_event(ns_event: &NSEvent) -> Self {
+        // `NSEventPhase` is an option set, but a single event reports one phase bit.
+        let phase = ns_event.phase();
+        if phase.contains(NSEventPhase::Began) {
+            Self::Began
+        } else if phase.contains(NSEventPhase::Changed) {
+            Self::Changed
+        } else if phase.contains(NSEventPhase::Ended) {
+            Self::Ended
+        } else if phase.contains(NSEventPhase::Cancelled) {
+            Self::Cancelled
+        } else if phase.contains(NSEventPhase::Stationary) {
+            Self::Stationary
+        } else if phase.contains(NSEventPhase::MayBegin) {
+            Self::MayBegin
+        } else {
+            Self::None
+        }
+    }
+}
+
+/// Pinch-to-zoom (`magnifyWithEvent:`). `magnification` is the incremental change for this event;
+/// accumulate it across a gesture (a full pinch sums to roughly ±1.0).
+#[repr(C)]
+#[derive(Debug)]
+pub struct MagnifyEvent {
+    pub window_id: WindowId,
+    pub magnification: f64,
+    pub phase: EventPhase,
+    pub location_in_window: LogicalPoint,
+    pub timestamp: Timestamp,
+}
+
+/// Two-finger rotation (`rotateWithEvent:`). `rotation` is the incremental change in degrees for
+/// this event (counter-clockwise is positive), to be accumulated across the gesture.
+#[repr(C)]
+#[derive(Debug)]
+pub struct RotateEvent {
+    pub window_id: WindowId,
+    pub rotation: f64,
+    pub phase: EventPhase,
+    pub location_in_window: LogicalPoint,
+    pub timestamp: Timestamp,
+}
+
+/// Two-finger double-tap "smart zoom" (`smartMagnifyWithEvent:`). Carries no magnitude; the consumer
+/// decides how to toggle zoom.
+#[repr(C)]
+#[derive(Debug)]
+pub struct SmartMagnifyEvent {
+    pub window_id: WindowId,
+    pub location_in_window: LogicalPoint,
+    pub timestamp: Timestamp,
+}
+
+/// Trackpad swipe (`swipeWithEvent:`). `delta_x`/`delta_y` indicate direction, typically -1, 0, or 1
+/// (a positive `delta_x` is a swipe to the left).
+#[repr(C)]
+#[derive(Debug)]
+pub struct SwipeEvent {
+    pub window_id: WindowId,
+    pub delta_x: f64,
+    pub delta_y: f64,
+    pub phase: EventPhase,
+    pub location_in_window: LogicalPoint,
+    pub timestamp: Timestamp,
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct WindowScreenChangeEvent {
@@ -202,6 +285,10 @@ pub enum Event<'a> {
     MouseDown(MouseDownEvent),
     MouseUp(MouseUpEvent),
     ScrollWheel(ScrollWheelEvent),
+    Magnify(MagnifyEvent),
+    Rotate(RotateEvent),
+    SmartMagnify(SmartMagnifyEvent),
+    Swipe(SwipeEvent),
     WindowScreenChange(WindowScreenChangeEvent),
     WindowResize(WindowResizeEvent),
     WindowMove(WindowMoveEvent),
@@ -346,44 +433,19 @@ pub(crate) fn handle_mouse_up(ns_event: &NSEvent) -> bool {
     handled
 }
 
-/// Some mice (e.g. Logitech MX Master) deliver the back/forward buttons as swipe
-/// gestures instead of `otherMouse*:` events. Translate them into a mouse click.
 pub(crate) fn handle_swipe(ns_event: &NSEvent) -> bool {
-    if ns_event.phase() != NSEventPhase::Ended {
-        return false;
-    }
-    let delta_x = ns_event.deltaX();
-    let button = if delta_x > 0.0 {
-        MouseButton(3) // back
-    } else if delta_x < 0.0 {
-        MouseButton(4) // forward
-    } else {
-        return false;
-    };
-    AppState::with(|state| {
-        let location_in_window = ns_event.cursor_location_in_window(state.mtm);
-        let timestamp = ns_event.timestamp();
-        let window_id = ns_event.window_id();
-        let down = Event::MouseDown(MouseDownEvent {
-            window_id,
-            button,
-            location_in_window,
-            click_count: 1,
-            timestamp,
+    let handled = AppState::with(|state| {
+        let event = Event::Swipe(SwipeEvent {
+            window_id: ns_event.window_id(),
+            delta_x: ns_event.deltaX(),
+            delta_y: ns_event.deltaY(),
+            phase: EventPhase::from_ns_event(ns_event),
+            location_in_window: ns_event.cursor_location_in_window(state.mtm),
+            timestamp: ns_event.timestamp(),
         });
-        let down_handled = (state.event_handler)(&down);
-        // The gesture has no physical release, so pair the down with a synthetic up to emit a
-        // balanced click for consumers that react on release or track pressed-button state.
-        let up = Event::MouseUp(MouseUpEvent {
-            window_id,
-            button,
-            location_in_window,
-            click_count: 1,
-            timestamp,
-        });
-        let up_handled = (state.event_handler)(&up);
-        down_handled || up_handled
-    })
+        (state.event_handler)(&event)
+    });
+    handled
 }
 
 pub(crate) fn handle_scroll_wheel(ns_event: &NSEvent) -> bool {
@@ -394,6 +456,46 @@ pub(crate) fn handle_scroll_wheel(ns_event: &NSEvent) -> bool {
             scrolling_delta_y: ns_event.scrollingDeltaY(),
             has_precise_scrolling_deltas: ns_event.hasPreciseScrollingDeltas(),
             is_direction_inverted: ns_event.isDirectionInvertedFromDevice(),
+            location_in_window: ns_event.cursor_location_in_window(state.mtm),
+            timestamp: ns_event.timestamp(),
+        });
+        (state.event_handler)(&event)
+    });
+    handled
+}
+
+pub(crate) fn handle_magnify(ns_event: &NSEvent) -> bool {
+    let handled = AppState::with(|state| {
+        let event = Event::Magnify(MagnifyEvent {
+            window_id: ns_event.window_id(),
+            magnification: ns_event.magnification(),
+            phase: EventPhase::from_ns_event(ns_event),
+            location_in_window: ns_event.cursor_location_in_window(state.mtm),
+            timestamp: ns_event.timestamp(),
+        });
+        (state.event_handler)(&event)
+    });
+    handled
+}
+
+pub(crate) fn handle_rotate(ns_event: &NSEvent) -> bool {
+    let handled = AppState::with(|state| {
+        let event = Event::Rotate(RotateEvent {
+            window_id: ns_event.window_id(),
+            rotation: f64::from(ns_event.rotation()),
+            phase: EventPhase::from_ns_event(ns_event),
+            location_in_window: ns_event.cursor_location_in_window(state.mtm),
+            timestamp: ns_event.timestamp(),
+        });
+        (state.event_handler)(&event)
+    });
+    handled
+}
+
+pub(crate) fn handle_smart_magnify(ns_event: &NSEvent) -> bool {
+    let handled = AppState::with(|state| {
+        let event = Event::SmartMagnify(SmartMagnifyEvent {
+            window_id: ns_event.window_id(),
             location_in_window: ns_event.cursor_location_in_window(state.mtm),
             timestamp: ns_event.timestamp(),
         });

--- a/native/desktop-macos/src/macos/events.rs
+++ b/native/desktop-macos/src/macos/events.rs
@@ -4,7 +4,7 @@ use core::f64;
 
 use anyhow::bail;
 use log::warn;
-use objc2_app_kit::{NSEvent, NSEventType, NSScreen, NSWindow, NSWindowOcclusionState};
+use objc2_app_kit::{NSEvent, NSEventPhase, NSEventType, NSScreen, NSWindow, NSWindowOcclusionState};
 use objc2_foundation::{MainThreadMarker, NSArray, NSURL};
 
 use desktop_common::{
@@ -344,6 +344,46 @@ pub(crate) fn handle_mouse_up(ns_event: &NSEvent) -> bool {
         (state.event_handler)(&event)
     });
     handled
+}
+
+/// Some mice (e.g. Logitech MX Master) deliver the back/forward buttons as swipe
+/// gestures instead of `otherMouse*:` events. Translate them into a mouse click.
+pub(crate) fn handle_swipe(ns_event: &NSEvent) -> bool {
+    if ns_event.phase() != NSEventPhase::Ended {
+        return false;
+    }
+    let delta_x = ns_event.deltaX();
+    let button = if delta_x > 0.0 {
+        MouseButton(3) // back
+    } else if delta_x < 0.0 {
+        MouseButton(4) // forward
+    } else {
+        return false;
+    };
+    AppState::with(|state| {
+        let location_in_window = ns_event.cursor_location_in_window(state.mtm);
+        let timestamp = ns_event.timestamp();
+        let window_id = ns_event.window_id();
+        let down = Event::MouseDown(MouseDownEvent {
+            window_id,
+            button,
+            location_in_window,
+            click_count: 1,
+            timestamp,
+        });
+        let down_handled = (state.event_handler)(&down);
+        // The gesture has no physical release, so pair the down with a synthetic up to emit a
+        // balanced click for consumers that react on release or track pressed-button state.
+        let up = Event::MouseUp(MouseUpEvent {
+            window_id,
+            button,
+            location_in_window,
+            click_count: 1,
+            timestamp,
+        });
+        let up_handled = (state.event_handler)(&up);
+        down_handled || up_handled
+    })
 }
 
 pub(crate) fn handle_scroll_wheel(ns_event: &NSEvent) -> bool {

--- a/native/desktop-macos/src/macos/window.rs
+++ b/native/desktop-macos/src/macos/window.rs
@@ -19,10 +19,10 @@ use crate::{
             handle_drag_target_updated,
         },
         events::{
-            handle_flags_change, handle_key_up_event, handle_mouse_down, handle_mouse_drag, handle_mouse_enter, handle_mouse_exit,
-            handle_mouse_move, handle_mouse_up, handle_scroll_wheel, handle_swipe, handle_window_changed_occlusion_state,
-            handle_window_close_request, handle_window_focus_change, handle_window_full_screen_toggle, handle_window_move,
-            handle_window_resize, handle_window_screen_change,
+            handle_flags_change, handle_key_up_event, handle_magnify, handle_mouse_down, handle_mouse_drag, handle_mouse_enter,
+            handle_mouse_exit, handle_mouse_move, handle_mouse_up, handle_rotate, handle_scroll_wheel, handle_smart_magnify, handle_swipe,
+            handle_window_changed_occlusion_state, handle_window_close_request, handle_window_focus_change,
+            handle_window_full_screen_toggle, handle_window_move, handle_window_resize, handle_window_screen_change,
         },
         string::copy_to_ns_string,
         text_input_client::NOT_FOUND_NS_RANGE,
@@ -879,6 +879,30 @@ define_class!(
         fn swipe_with_event(&self, event: &NSEvent) {
             catch_panic(|| {
                 handle_swipe(event);
+                Ok(())
+            });
+        }
+
+        #[unsafe(method(magnifyWithEvent:))]
+        fn magnify_with_event(&self, event: &NSEvent) {
+            catch_panic(|| {
+                handle_magnify(event);
+                Ok(())
+            });
+        }
+
+        #[unsafe(method(rotateWithEvent:))]
+        fn rotate_with_event(&self, event: &NSEvent) {
+            catch_panic(|| {
+                handle_rotate(event);
+                Ok(())
+            });
+        }
+
+        #[unsafe(method(smartMagnifyWithEvent:))]
+        fn smart_magnify_with_event(&self, event: &NSEvent) {
+            catch_panic(|| {
+                handle_smart_magnify(event);
                 Ok(())
             });
         }

--- a/native/desktop-macos/src/macos/window.rs
+++ b/native/desktop-macos/src/macos/window.rs
@@ -20,9 +20,9 @@ use crate::{
         },
         events::{
             handle_flags_change, handle_key_up_event, handle_mouse_down, handle_mouse_drag, handle_mouse_enter, handle_mouse_exit,
-            handle_mouse_move, handle_mouse_up, handle_scroll_wheel, handle_window_changed_occlusion_state, handle_window_close_request,
-            handle_window_focus_change, handle_window_full_screen_toggle, handle_window_move, handle_window_resize,
-            handle_window_screen_change,
+            handle_mouse_move, handle_mouse_up, handle_scroll_wheel, handle_swipe, handle_window_changed_occlusion_state,
+            handle_window_close_request, handle_window_focus_change, handle_window_full_screen_toggle, handle_window_move,
+            handle_window_resize, handle_window_screen_change,
         },
         string::copy_to_ns_string,
         text_input_client::NOT_FOUND_NS_RANGE,
@@ -871,6 +871,14 @@ define_class!(
         fn other_mouse_up(&self, event: &NSEvent) {
             catch_panic(|| {
                 handle_mouse_up(event);
+                Ok(())
+            });
+        }
+
+        #[unsafe(method(swipeWithEvent:))]
+        fn swipe_with_event(&self, event: &NSEvent) {
+            catch_panic(|| {
+                handle_swipe(event);
                 Ok(())
             });
         }

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/macos/SkikoSampleMac.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/macos/SkikoSampleMac.kt
@@ -538,6 +538,22 @@ class ApplicationState : AutoCloseable {
                 Logger.info { "$event" }
             }
 
+            is Event.Magnify -> {
+                Logger.info { "$event" }
+            }
+
+            is Event.Rotate -> {
+                Logger.info { "$event" }
+            }
+
+            is Event.SmartMagnify -> {
+                Logger.info { "$event" }
+            }
+
+            is Event.Swipe -> {
+                Logger.info { "$event" }
+            }
+
 //            is Event.MouseEntered -> {
 //                Logger.info { "$event" }
 //            }


### PR DESCRIPTION
Some mice (e.g. Logitech MX Master) deliver the navigation (back/forward) buttons as swipe gestures, so those buttons never reached the regular mouse handlers.