### PR TITLE
feat(win32): custom drag image for drag-and-drop

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DragDrop.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DragDrop.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.desktop.win32
 
+import org.jetbrains.desktop.win32.generated.NativeBorrowedArray_u8
 import org.jetbrains.desktop.win32.generated.NativeDragSourceCallbacks
 import org.jetbrains.desktop.win32.generated.NativeDropTargetCallbacks
+import org.jetbrains.desktop.win32.generated.NativePhysicalPoint
 import org.jetbrains.desktop.win32.generated.desktop_win32_h
 import java.lang.foreign.Arena
 import java.lang.foreign.MemorySegment
@@ -22,10 +24,37 @@ public class DragDropManager(private val window: Window) : AutoCloseable {
         }
     }
 
-    public fun doDragDrop(dataObject: DataObject, allowedEffects: DragDropEffect, dragSource: DragSource): DragDropEffect {
+    /**
+     * Starts a synchronous drag-and-drop operation sourced from this window, returning when it ends.
+     *
+     * @param dataObject the data offered to drop targets during the drag.
+     * @param allowedEffects the drop effects this source permits (e.g. copy, move, link).
+     * @param dragSource callbacks deciding whether to continue, cancel, or complete the drag.
+     * @param dragImage optional custom image shown under the cursor during the drag; when null the
+     * system default drag feedback is used.
+     * @return the drop effect performed by the target.
+     */
+    public fun doDragDrop(
+        dataObject: DataObject,
+        allowedEffects: DragDropEffect,
+        dragSource: DragSource,
+        dragImage: DragImage? = null,
+    ): DragDropEffect {
         val effect = DragSourceCallbacks(dragSource).use { callbacks ->
-            ffiDownCall {
-                desktop_win32_h.drag_drop_start(dataObject.toNative(), allowedEffects.value, callbacks.toNative())
+            Arena.ofConfined().use { arena ->
+                // A zeroed BorrowedArray is a null pointer + 0 length, which the native side reads as
+                // "no image"; the offset is then unused.
+                val imageBytes = dragImage?.image?.toNative(arena) ?: NativeBorrowedArray_u8.allocate(arena)
+                val imageOffset = dragImage?.cursorOffset?.toNative(arena) ?: NativePhysicalPoint.allocate(arena)
+                ffiDownCall {
+                    desktop_win32_h.drag_drop_start(
+                        dataObject.toNative(),
+                        allowedEffects.value,
+                        imageBytes,
+                        imageOffset,
+                        callbacks.toNative(),
+                    )
+                }
             }
         }
         return DragDropEffect(effect)
@@ -43,6 +72,21 @@ public class DragDropManager(private val window: Window) : AutoCloseable {
 
     override fun close() {
         dropTargetCallbacks?.close()
+    }
+}
+
+/**
+ * A custom drag image shown under the cursor during a drag-and-drop operation.
+ *
+ * @property image an encoded image (e.g. PNG) the system decodes for display.
+ * @property cursorOffset the cursor's position within the image, in physical pixels.
+ */
+public class DragImage(
+    public val image: ByteArray,
+    public val cursorOffset: PhysicalPoint,
+) {
+    init {
+        require(image.isNotEmpty()) { "Drag image must not be empty" }
     }
 }
 

--- a/native/desktop-win32/Cargo.toml
+++ b/native/desktop-win32/Cargo.toml
@@ -39,6 +39,7 @@ windows = { version = "0.62.2", features = [
     "Win32_Graphics_Dwm",
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Gdi",
+    "Win32_Graphics_Imaging",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_DataExchange",

--- a/native/desktop-win32/docs/ARCHITECTURE.md
+++ b/native/desktop-win32/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ native/
         drag_drop.rs              IDropSource / IDropTarget via windows-core implement!
         drag_drop_api.rs          FFI: drag_drop_register_target / start / revoke
         wic_image.rs              WIC decode: encoded image → top-down 32bpp straight-BGRA DIB (WicBitmap)
-        data_object.rs            IDataObject impl backed by papaya::HashMap<u32, HGlobalData>
+        data_object.rs            IDataObject impl backed by papaya::HashMap<u32, StoredMedium>
         data_object_api.rs        Global registry (id→ComObject); result-bearing read API
         data_reader.rs            STGMEDIUM RAII; HGLOBAL/IStream-uniform get_*
         data_transfer.rs          DataFormat enum + DataTransfer* result vocabulary (DataTransferStatus / DataTransferFailure)

--- a/native/desktop-win32/docs/ARCHITECTURE.md
+++ b/native/desktop-win32/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ native/
       lib.rs                      DllMain → captures HINSTANCE; declares win32 + logger_api
       logger_api.rs               thin Win32 logger glue
       win32/
-        mod.rs                    declares 39 sibling pub mod entries
+        mod.rs                    declares 41 sibling pub mod entries
         application.rs            Application: OLE STA, DispatcherQueue, CompositorDriver
         application_api.rs        FFI: app lifecycle + dispatcher dispatch
         event_loop.rs             window_proc: WM_* → Event dispatch; thread_local key/exception stash
@@ -77,6 +77,7 @@ native/
         clipboard_api.rs          FFI: OLE-backed clipboard read/write/clear + sequence helpers
         drag_drop.rs              IDropSource / IDropTarget via windows-core implement!
         drag_drop_api.rs          FFI: drag_drop_register_target / start / revoke
+        wic_image.rs              WIC decode: encoded image → top-down 32bpp straight-BGRA DIB (WicBitmap)
         data_object.rs            IDataObject impl backed by papaya::HashMap<u32, HGlobalData>
         data_object_api.rs        Global registry (id→ComObject); result-bearing read API
         data_reader.rs            STGMEDIUM RAII; HGLOBAL/IStream-uniform get_*

--- a/native/desktop-win32/docs/SUBSYSTEMS.md
+++ b/native/desktop-win32/docs/SUBSYSTEMS.md
@@ -336,7 +336,7 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 **FFI surface.** `data_object_create() -> i64`, `data_object_drop(i64)`, `data_object_add_from_{bytes,file_list,html_fragment,text}`, `data_object_into_com() -> ComInterfaceRawPtr`, result-bearing `com_data_object_{is_format_available,enum_formats,read_bytes,read_file_list,read_html_fragment,read_text}_result`, `com_data_object_retain`, `com_data_object_release`, `native_u32_array_drop`, `native_byte_array_drop`.
 
 **Key types.**
-- `DataObject` (Rust) — `#[implement(IDataObject)]`. `papaya::HashMap<u32, HGlobalData>` keyed on cfFormat (cast to u32). Implements `GetData`, `EnumFormatEtc`, `QueryGetData`. `SetData`, `GetDataHere`, `DAdvise*` return `E_NOTIMPL` / `OLE_E_ADVISENOTSUPPORTED`.
+- `DataObject` (Rust) — `#[implement(IDataObject)]`. `papaya::HashMap<u32, HGlobalData>` keyed on cfFormat (cast to u32). Implements `GetData`, `EnumFormatEtc`, `QueryGetData`, and `SetData` — which accepts `TYMED_HGLOBAL` and `TYMED_ISTREAM` private formats (an ISTREAM medium's bytes are copied into an owned HGLOBAL; `ReleaseStgMedium` on `fRelease`; other tymeds → `DV_E_TYMED`). `GetData` still serves stored formats as `TYMED_HGLOBAL`. `GetDataHere`, `DAdvise*` return `E_NOTIMPL` / `OLE_E_ADVISENOTSUPPORTED`.
 - Global registry: `static DATA_OBJECT_REGISTRY: papaya::HashMap<i64, ComObject<DataObject>>` keyed on `AtomicI64` IDs. `data_object_create` inserts; `data_object_into_com` removes and converts to `ComInterfaceRawPtr` for OS hand-off.
 - `DataObject` (Kotlin, `AutoCloseable`) — wraps the `ComInterfaceRawPtr`. `requireOpen` guard. `read*` (throwing) and `tryRead*` (nullable) variants.
 - `DataObjectBuilder` (Kotlin) — used inside `DataObject.build { … }` block-scoped builder. Hides the `data_object_create` → populate → `data_object_into_com` lifecycle.
@@ -397,27 +397,30 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 
 ## Drag-and-drop
 
-**Purpose.** Bidirectional OLE drag-drop: implements both `IDropSource` (start a drag) and `IDropTarget` (receive a drop), bridging the COM callbacks to Kotlin function pointers via `DropTargetCallbacks` / `DragSourceCallbacks` structs.
+**Purpose.** Bidirectional OLE drag-drop: implements both `IDropSource` (start a drag) and `IDropTarget` (receive a drop), bridging the COM callbacks to Kotlin function pointers via `DropTargetCallbacks` / `DragSourceCallbacks` structs. Both directions integrate the Shell drag-image helper (`CLSID_DragDropHelper`) so a source drag can show a custom image and drop targets render the OS drag image.
 
-**Files.** `drag_drop.rs`, `drag_drop_api.rs` + Kotlin `DragDrop.kt`.
+**Files.** `drag_drop.rs`, `drag_drop_api.rs`, `wic_image.rs` (drag-image decode → `SHDRAGIMAGE`) + Kotlin `DragDrop.kt`.
 
-**FFI surface.** `drag_drop_register_target`, `drag_drop_start`, `drag_drop_revoke_target`.
+**FFI surface.** `drag_drop_register_target`, `drag_drop_start` (also takes `drag_image_bytes: BorrowedArray<u8>` + `drag_image_offset: PhysicalPoint`; a null byte array means no image), `drag_drop_revoke_target`.
 
 **Key types.**
 - `DropTarget`, `DragSource` — `windows-core` `implement!`-decorated COM impls.
 - `DropTargetCallbacks` — `extern "C"` function pointers held by `DropTarget`. Allocated by Kotlin in an `Arena.ofShared()` whose lifetime matches the `DragDropManager`.
 - `DragSourceCallbacks` — same pattern for the source side.
 - `DragDropManager` (Kotlin, `AutoCloseable`).
+- `DragImage` (Kotlin) — optional custom drag image passed to `doDragDrop`: encoded image bytes + a `PhysicalPoint` cursor offset.
+- `WicBitmap` (Rust, `wic_image.rs`) — RAII owner of a decoded top-down 32bpp straight-BGRA DIB; `decode_from_bytes` (WIC) builds it, `into_handle()` hands the `HBITMAP` to an `SHDRAGIMAGE` and otherwise frees it on drop.
 
 **Mechanism.**
-- Drop side: `RegisterDragDrop(hwnd, drop_target)` registers our `IDropTarget`. Win32 calls `DragEnter` / `DragOver` / `DragLeave` / `Drop` with an `IDataObject`. We wrap that as `ComInterfaceRawPtr` and upcall to Kotlin.
-- Source side: `DoDragDrop(data_object, drop_source, allowed_effects, &mut effect)`. `DragSource::GiveFeedback` always returns `DRAGDROP_S_USEDEFAULTCURSORS`.
+- Drop side: `RegisterDragDrop(hwnd, drop_target)` registers our `IDropTarget`. Win32 calls `DragEnter` / `DragOver` / `DragLeave` / `Drop` with an `IDataObject`. We wrap that as `ComInterfaceRawPtr` and upcall to Kotlin, then forward each call to an `IDropTargetHelper` (created at registration) so the OS drag image renders over the window.
+- Source side: `DoDragDrop(data_object, drop_source, allowed_effects, &mut effect)`. `DragSource::GiveFeedback` always returns `DRAGDROP_S_USEDEFAULTCURSORS`. When a `DragImage` is supplied, before `DoDragDrop` we create an `IDragSourceHelper` and call `InitializeFromBitmap` with the `SHDRAGIMAGE` from `create_drag_image` (which decodes via `WicBitmap`); on success the helper owns the `HBITMAP`, freed by us only on failure.
 - `drag_drop_revoke_target` calls `RevokeDragDrop`.
 
 **Gotchas.**
 - **`ComInterfaceRawPtr` lifetime in callbacks** (drag_drop.rs). The `DataObject(rawPtr)` Kotlin instance constructed inside `dragEnter` / `drop` wraps a pointer whose validity is bounded by the COM callback. If Kotlin stores that `DataObject` beyond the callback, the pointer escapes. Currently no enforcement.
 - Module-blanket `#![allow(clippy::inline_always)]` and `#![allow(clippy::ref_as_ptr)]` (drag_drop.rs) — same as `data_object.rs`, inherited from `implement!`.
 - COM callbacks arrive on the STA thread; the confined `Arena` for callback stubs is single-thread, so this is consistent only as long as drag-drop stays on the STA thread.
+- Drag-image helper calls are cosmetic and best-effort: a missing helper or an `IDropTargetHelper` forwarding error is swallowed, never altering the drop result. `SetData` normalizes a `TYMED_ISTREAM` format into HGLOBAL, so `GetData` serves it as `TYMED_HGLOBAL` — an ISTREAM-only `GetData` would miss it (deferred; see the HGLOBAL→IStream direction).
 
 **Cross-refs.** `data_object` (the wrapped `IDataObject`), `com.rs` (`ComInterfaceRawPtr`), `geometry` (`PhysicalPoint` from `POINTL`), `window`.
 

--- a/native/desktop-win32/docs/SUBSYSTEMS.md
+++ b/native/desktop-win32/docs/SUBSYSTEMS.md
@@ -329,14 +329,14 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 
 ## DataObject
 
-**Purpose.** Rust-implemented `IDataObject` backed by a `papaya::HashMap<u32, HGlobalData>`. Both ends of the OLE clipboard / drag-drop path use it: it's the Rust-side container that Kotlin populates and hands to Win32, and it's also the wrapper that reads back from any `IDataObject` (own or external) via `data_object_api`'s `com_data_object_*` functions.
+**Purpose.** Rust-implemented `IDataObject` backed by a `papaya::HashMap<u32, StoredMedium>`. Both ends of the OLE clipboard / drag-drop path use it: it's the Rust-side container that Kotlin populates and hands to Win32, and it's also the wrapper that reads back from any `IDataObject` (own or external) via `data_object_api`'s `com_data_object_*` functions.
 
 **Files.** `data_object.rs`, `data_object_api.rs` + Kotlin `DataObject.kt`, `DataFormat.kt`.
 
 **FFI surface.** `data_object_create() -> i64`, `data_object_drop(i64)`, `data_object_add_from_{bytes,file_list,html_fragment,text}`, `data_object_into_com() -> ComInterfaceRawPtr`, result-bearing `com_data_object_{is_format_available,enum_formats,read_bytes,read_file_list,read_html_fragment,read_text}_result`, `com_data_object_retain`, `com_data_object_release`, `native_u32_array_drop`, `native_byte_array_drop`.
 
 **Key types.**
-- `DataObject` (Rust) — `#[implement(IDataObject)]`. `papaya::HashMap<u32, HGlobalData>` keyed on cfFormat (cast to u32). Implements `GetData`, `EnumFormatEtc`, `QueryGetData`, and `SetData` — which accepts `TYMED_HGLOBAL` and `TYMED_ISTREAM` private formats (an ISTREAM medium's bytes are copied into an owned HGLOBAL; `ReleaseStgMedium` on `fRelease`; other tymeds → `DV_E_TYMED`). `GetData` still serves stored formats as `TYMED_HGLOBAL`. `GetDataHere`, `DAdvise*` return `E_NOTIMPL` / `OLE_E_ADVISENOTSUPPORTED`.
+- `DataObject` (Rust) — `#[implement(IDataObject)]`. `papaya::HashMap<u32, StoredMedium>` keyed on cfFormat (cast to u32), where `StoredMedium` is `HGlobal(HGlobalData)` or `Stream(IAgileReference)` — each format keeps the medium it was set with. Implements `GetData`, `EnumFormatEtc`, `QueryGetData`, and `SetData` — which accepts `TYMED_HGLOBAL` (contents copied into an owned HGLOBAL) and `TYMED_ISTREAM` (retained as an agile reference via `RoGetAgileReference`, not byte-copied), calls `ReleaseStgMedium` only on success + `fRelease`, and rejects other tymeds with `DV_E_TYMED`. `GetData` serves each format back with its stored medium — an HGLOBAL copy or a `Resolve()`d `IStream` — so a stream round-trips as `TYMED_ISTREAM`; `GetData` / `QueryGetData` return granular `DV_E_FORMATETC` / `DV_E_DVASPECT` / `DV_E_TYMED`, and `EnumFormatEtc` advertises each format's real tymed. `GetDataHere`, `DAdvise*` return `E_NOTIMPL` / `OLE_E_ADVISENOTSUPPORTED`.
 - Global registry: `static DATA_OBJECT_REGISTRY: papaya::HashMap<i64, ComObject<DataObject>>` keyed on `AtomicI64` IDs. `data_object_create` inserts; `data_object_into_com` removes and converts to `ComInterfaceRawPtr` for OS hand-off.
 - `DataObject` (Kotlin, `AutoCloseable`) — wraps the `ComInterfaceRawPtr`. `requireOpen` guard. `read*` (throwing) and `tryRead*` (nullable) variants.
 - `DataObjectBuilder` (Kotlin) — used inside `DataObject.build { … }` block-scoped builder. Hides the `data_object_create` → populate → `data_object_into_com` lifecycle.
@@ -413,14 +413,14 @@ Some of these exceptions are up for re-evaluation. The `DropTarget` callbacks, f
 
 **Mechanism.**
 - Drop side: `RegisterDragDrop(hwnd, drop_target)` registers our `IDropTarget`. Win32 calls `DragEnter` / `DragOver` / `DragLeave` / `Drop` with an `IDataObject`. We wrap that as `ComInterfaceRawPtr` and upcall to Kotlin, then forward each call to an `IDropTargetHelper` (created at registration) so the OS drag image renders over the window.
-- Source side: `DoDragDrop(data_object, drop_source, allowed_effects, &mut effect)`. `DragSource::GiveFeedback` always returns `DRAGDROP_S_USEDEFAULTCURSORS`. When a `DragImage` is supplied, before `DoDragDrop` we create an `IDragSourceHelper` and call `InitializeFromBitmap` with the `SHDRAGIMAGE` from `create_drag_image` (which decodes via `WicBitmap`); on success the helper owns the `HBITMAP`, freed by us only on failure.
+- Source side: `DoDragDrop(data_object, drop_source, allowed_effects, &mut effect)`. `DragSource::GiveFeedback` always returns `DRAGDROP_S_USEDEFAULTCURSORS`. When a `DragImage` is supplied, before `DoDragDrop` we create an `IDragSourceHelper2` and call `SetFlags(DSH_ALLOWDROPDESCRIPTIONTEXT)` (so a drop target's drop-description text renders over the custom image) before `InitializeFromBitmap` with the `SHDRAGIMAGE` from `create_drag_image` (which decodes via `WicBitmap`); on success the helper owns the `HBITMAP`, freed by us only on failure.
 - `drag_drop_revoke_target` calls `RevokeDragDrop`.
 
 **Gotchas.**
 - **`ComInterfaceRawPtr` lifetime in callbacks** (drag_drop.rs). The `DataObject(rawPtr)` Kotlin instance constructed inside `dragEnter` / `drop` wraps a pointer whose validity is bounded by the COM callback. If Kotlin stores that `DataObject` beyond the callback, the pointer escapes. Currently no enforcement.
 - Module-blanket `#![allow(clippy::inline_always)]` and `#![allow(clippy::ref_as_ptr)]` (drag_drop.rs) — same as `data_object.rs`, inherited from `implement!`.
 - COM callbacks arrive on the STA thread; the confined `Arena` for callback stubs is single-thread, so this is consistent only as long as drag-drop stays on the STA thread.
-- Drag-image helper calls are cosmetic and best-effort: a missing helper or an `IDropTargetHelper` forwarding error is swallowed, never altering the drop result. `SetData` normalizes a `TYMED_ISTREAM` format into HGLOBAL, so `GetData` serves it as `TYMED_HGLOBAL` — an ISTREAM-only `GetData` would miss it (deferred; see the HGLOBAL→IStream direction).
+- Drag-image helper calls are cosmetic and best-effort: a missing helper or an `IDropTargetHelper` forwarding error is swallowed, never altering the drop result. `SetData` preserves each format's medium — an `IStream` is retained as an agile reference and served back as `TYMED_ISTREAM`, which the Shell drag-image helper needs to read its `DragContext` stream back cross-process.
 
 **Cross-refs.** `data_object` (the wrapped `IDataObject`), `com.rs` (`ComInterfaceRawPtr`), `geometry` (`PhysicalPoint` from `POINTL`), `window`.
 

--- a/native/desktop-win32/src/win32/data_object.rs
+++ b/native/desktop-win32/src/win32/data_object.rs
@@ -10,7 +10,7 @@ use windows::Win32::{
     System::{
         Com::{
             DATADIR, DATADIR_GET, DVASPECT_CONTENT, FORMATETC, IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
-            STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL, TYMED_ISTREAM,
+            STGMEDIUM, STGMEDIUM_0, TYMED, TYMED_HGLOBAL, TYMED_ISTREAM,
         },
         Ole::ReleaseStgMedium,
     },
@@ -18,7 +18,7 @@ use windows::Win32::{
 };
 use windows_core::{BOOL, Error as WinError, HRESULT, Ref as WinRef, Result as WinResult, implement};
 
-use super::{data_transfer::DataFormat, global_data::HGlobalData};
+use super::{data_reader::istream_reader, data_transfer::DataFormat, global_data::HGlobalData};
 
 #[implement(IDataObject)]
 pub struct DataObject {
@@ -104,12 +104,19 @@ impl IDataObject_Impl for DataObject_Impl {
         // Borrow the medium mutably so one reference both reads its fields and releases it in place
         // on fRelease. The SetData C ABI passes a non-const STGMEDIUM*, modeled here as *const.
         let medium = unsafe { medium_in.cast_mut().as_mut() }.ok_or_else(|| WinError::from(E_POINTER))?;
-        if medium.tymed != TYMED_HGLOBAL.0.cast_unsigned() {
-            return Err(DV_E_TYMED.into());
-        }
-        let hglobal = unsafe { medium.u.hGlobal };
-        // Copy the source bytes into an owned HGLOBAL before any release.
-        let data = HGlobalData::copy_from(HANDLE(hglobal.0)).map_err(|err| {
+        // The drag-image helper stores its private formats as both HGLOBAL and ISTREAM. Normalize
+        // either into an owned HGLOBAL copy so the rest of the data object only handles HGLOBAL; for
+        // an ISTREAM the bytes are read out and copied, never the live stream retained.
+        let medium_data: anyhow::Result<HGlobalData> = match TYMED(medium.tymed.cast_signed()) {
+            TYMED_HGLOBAL => HGlobalData::copy_from(HANDLE(unsafe { medium.u.hGlobal }.0)),
+            TYMED_ISTREAM => match unsafe { (*medium.u.pstm).as_ref() } {
+                Some(stream) => istream_reader::get_bytes(stream).and_then(|bytes| HGlobalData::alloc_from(&bytes)),
+                None => Err(anyhow::anyhow!("data object received a null IStream")),
+            },
+            _ => return Err(DV_E_TYMED.into()),
+        };
+        let data = medium_data.map_err(|err| {
+            log::error!("DataObject::SetData failed: {err:?}");
             // Surface the original Win32 HRESULT when the failure chain carries one.
             err.chain()
                 .find_map(|cause| cause.downcast_ref::<WinError>())
@@ -199,8 +206,10 @@ mod tests {
     use windows::Win32::{
         Foundation::{DATA_S_SAMEFORMATETC, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_OK},
         System::Com::{
-            DATADIR_SET, DVASPECT_DOCPRINT, FORMATETC, IAdviseSink, IDataObject, STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL, TYMED_ISTREAM,
+            DATADIR_SET, DVASPECT_DOCPRINT, FORMATETC, IAdviseSink, IDataObject, STGMEDIUM, STGMEDIUM_0, TYMED_GDI, TYMED_HGLOBAL,
+            TYMED_ISTREAM,
         },
+        UI::Shell::SHCreateMemStream,
     };
     use windows_core::ComObject;
 
@@ -264,14 +273,37 @@ mod tests {
     }
 
     #[test]
-    fn set_data_with_non_hglobal_tymed_returns_dv_e_tymed() {
-        let medium = hglobal_medium(TYMED_ISTREAM.0, windows::Win32::Foundation::HGLOBAL::default());
+    fn set_data_with_unsupported_tymed_returns_dv_e_tymed() {
+        // TYMED_GDI is neither HGLOBAL nor ISTREAM, the two the data object accepts.
+        let medium = hglobal_medium(TYMED_GDI.0, windows::Win32::Foundation::HGLOBAL::default());
         let data_object: IDataObject = DataObject::new().into();
         let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
 
         let err = unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap_err();
 
         assert_eq!(err.code(), DV_E_TYMED);
+    }
+
+    #[test]
+    fn set_data_with_istream_copies_bytes_to_hglobal() {
+        // The drag-image helper sets a TYMED_ISTREAM private format; the data object must read its
+        // bytes and serve them back as HGLOBAL.
+        let payload: &[u8] = b"istream-drag-context";
+        let stream = unsafe { SHCreateMemStream(Some(payload)) }.expect("SHCreateMemStream returned null");
+        let medium = STGMEDIUM {
+            tymed: TYMED_ISTREAM.0.cast_unsigned(),
+            u: STGMEDIUM_0 {
+                pstm: ManuallyDrop::new(Some(stream)),
+            },
+            pUnkForRelease: ManuallyDrop::new(None),
+        };
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        // fRelease == TRUE: SetData reads the stream's bytes, then releases the stream.
+        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, true) }.unwrap();
+
+        assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), payload.to_vec());
     }
 
     #[test]

--- a/native/desktop-win32/src/win32/data_object.rs
+++ b/native/desktop-win32/src/win32/data_object.rs
@@ -4,10 +4,15 @@
 use std::mem::ManuallyDrop;
 
 use windows::Win32::{
-    Foundation::{DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, HGLOBAL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK},
-    System::Com::{
-        DATADIR, DATADIR_GET, DVASPECT_CONTENT, FORMATETC, IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
-        STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL, TYMED_ISTREAM,
+    Foundation::{
+        DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE, HGLOBAL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
+    },
+    System::{
+        Com::{
+            DATADIR, DATADIR_GET, DVASPECT_CONTENT, FORMATETC, IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
+            STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL, TYMED_ISTREAM,
+        },
+        Ole::ReleaseStgMedium,
     },
     UI::Shell::SHCreateStdEnumFmtEtc,
 };
@@ -93,9 +98,31 @@ impl IDataObject_Impl for DataObject_Impl {
         windows::Win32::Foundation::DATA_S_SAMEFORMATETC
     }
 
-    fn SetData(&self, _format_etc: *const FORMATETC, _medium: *const STGMEDIUM, _release: BOOL) -> WinResult<()> {
-        // We don't support setting arbitrary data to the data object after its creation through the COM interface
-        Err(E_NOTIMPL.into())
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn SetData(&self, format_etc_in: *const FORMATETC, medium_in: *const STGMEDIUM, release: BOOL) -> WinResult<()> {
+        let format_etc = unsafe { format_etc_in.as_ref() }.ok_or_else(|| WinError::from(E_POINTER))?;
+        // Borrow the medium mutably so one reference both reads its fields and releases it in place
+        // on fRelease. The SetData C ABI passes a non-const STGMEDIUM*, modeled here as *const.
+        let medium = unsafe { medium_in.cast_mut().as_mut() }.ok_or_else(|| WinError::from(E_POINTER))?;
+        if medium.tymed != TYMED_HGLOBAL.0.cast_unsigned() {
+            return Err(DV_E_TYMED.into());
+        }
+        let hglobal = unsafe { medium.u.hGlobal };
+        // Copy the source bytes into an owned HGLOBAL before any release.
+        let data = HGlobalData::copy_from(HANDLE(hglobal.0)).map_err(|err| {
+            // Surface the original Win32 HRESULT when the failure chain carries one.
+            err.chain()
+                .find_map(|cause| cause.downcast_ref::<WinError>())
+                .cloned()
+                .unwrap_or_else(|| WinError::from(E_UNEXPECTED))
+        })?;
+        // SetData replaces any existing data for the format, per the IDataObject contract.
+        self.hash_map.pin().insert(u32::from(format_etc.cfFormat), data);
+        // fRelease == TRUE hands the medium's ownership to us; free it now that the bytes are copied.
+        if release.as_bool() {
+            unsafe { ReleaseStgMedium(medium) };
+        }
+        Ok(())
     }
 
     fn EnumFormatEtc(&self, direction: u32) -> WinResult<IEnumFORMATETC> {
@@ -162,5 +189,236 @@ fn get_format_etc_for_hglobal(data_format: DataFormat) -> FORMATETC {
         dwAspect: DVASPECT_CONTENT.0,
         lindex: -1,
         tymed: TYMED_HGLOBAL.0.cast_unsigned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::ManuallyDrop;
+
+    use windows::Win32::{
+        Foundation::{DATA_S_SAMEFORMATETC, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_OK},
+        System::Com::{
+            DATADIR_SET, DVASPECT_DOCPRINT, FORMATETC, IAdviseSink, IDataObject, STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL, TYMED_ISTREAM,
+        },
+    };
+    use windows_core::ComObject;
+
+    use super::{DataFormat, DataObject, get_format_etc_for_hglobal};
+    use crate::win32::global_data::{HGlobalData, hglobal_reader, hglobal_writer};
+
+    const CUSTOM_FORMAT: u32 = 0xC123;
+    const UNKNOWN_FORMAT: u32 = 0xC456;
+
+    fn hglobal_medium(tymed: i32, hglobal: windows::Win32::Foundation::HGLOBAL) -> STGMEDIUM {
+        STGMEDIUM {
+            tymed: tymed.cast_unsigned(),
+            u: STGMEDIUM_0 { hGlobal: hglobal },
+            pUnkForRelease: ManuallyDrop::new(None),
+        }
+    }
+
+    fn read_get_data_bytes(data_object: &IDataObject, format_id: u32) -> Vec<u8> {
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(format_id));
+        let medium = unsafe { data_object.GetData(&raw const format_etc) }.unwrap();
+        let copied = HGlobalData::copy_from(HANDLE(unsafe { medium.u.hGlobal }.0)).unwrap();
+        hglobal_reader::get_bytes(&copied).unwrap()
+    }
+
+    #[test]
+    fn set_data_then_get_data_returns_same_bytes() {
+        let source = hglobal_writer::new_bytes(b"drag-image-bits").unwrap();
+        let medium = hglobal_medium(TYMED_HGLOBAL.0, source.as_raw());
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap();
+
+        assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), b"drag-image-bits");
+    }
+
+    #[test]
+    fn query_get_data_returns_s_ok_for_set_format() {
+        let source = hglobal_writer::new_bytes(b"payload").unwrap();
+        let medium = hglobal_medium(TYMED_HGLOBAL.0, source.as_raw());
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap();
+
+        let result = unsafe { data_object.QueryGetData(&raw const format_etc) };
+
+        assert_eq!(result, S_OK);
+    }
+
+    #[test]
+    fn enum_format_etc_includes_set_format() {
+        let source = hglobal_writer::new_bytes(b"payload").unwrap();
+        let medium = hglobal_medium(TYMED_HGLOBAL.0, source.as_raw());
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap();
+
+        let ids = super::enum_data_object_format_ids(&data_object).unwrap();
+
+        assert!(ids.contains(&CUSTOM_FORMAT));
+    }
+
+    #[test]
+    fn set_data_with_non_hglobal_tymed_returns_dv_e_tymed() {
+        let medium = hglobal_medium(TYMED_ISTREAM.0, windows::Win32::Foundation::HGLOBAL::default());
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let err = unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap_err();
+
+        assert_eq!(err.code(), DV_E_TYMED);
+    }
+
+    #[test]
+    fn set_data_with_release_true_succeeds() {
+        let mut source = hglobal_writer::new_bytes(b"owned-by-data-object").unwrap();
+        let medium = hglobal_medium(TYMED_HGLOBAL.0, source.as_raw());
+        // fRelease == TRUE transfers the medium to the data object, which frees it after copying;
+        // detach so this owner does not also free the same handle.
+        source.detach();
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let result = unsafe { data_object.SetData(&raw const format_etc, &raw const medium, true) };
+
+        assert!(result.is_ok());
+        assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), b"owned-by-data-object");
+    }
+
+    #[test]
+    fn add_format_then_get_data_returns_same_bytes() {
+        let data_object = ComObject::new(DataObject::new());
+        let data = hglobal_writer::new_bytes(b"app-data-bits").unwrap();
+        assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), data));
+        let iface: IDataObject = data_object.to_interface();
+
+        assert_eq!(read_get_data_bytes(&iface, CUSTOM_FORMAT), b"app-data-bits");
+    }
+
+    #[test]
+    fn get_data_for_unknown_format_returns_dv_e_formatetc() {
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(UNKNOWN_FORMAT));
+
+        // STGMEDIUM is not Debug, so inspect the error without unwrap_err.
+        let code = unsafe { data_object.GetData(&raw const format_etc) }.err().map(|err| err.code());
+
+        assert_eq!(code, Some(DV_E_FORMATETC));
+    }
+
+    #[test]
+    fn query_get_data_for_unknown_format_returns_dv_e_formatetc() {
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(UNKNOWN_FORMAT));
+
+        let result = unsafe { data_object.QueryGetData(&raw const format_etc) };
+
+        assert_eq!(result, DV_E_FORMATETC);
+    }
+
+    #[test]
+    fn add_format_with_duplicate_id_returns_false_and_retains_first_value() {
+        let data_object = ComObject::new(DataObject::new());
+        let first = hglobal_writer::new_bytes(b"first").unwrap();
+        let second = hglobal_writer::new_bytes(b"second").unwrap();
+        assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), first));
+
+        // try_insert refuses the duplicate id, so the first value stays in place.
+        assert!(!data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), second));
+
+        let iface: IDataObject = data_object.to_interface();
+        assert_eq!(read_get_data_bytes(&iface, CUSTOM_FORMAT), b"first");
+    }
+
+    #[test]
+    fn get_canonical_format_etc_reports_same_format_and_nulls_ptd() {
+        let data_object: IDataObject = DataObject::new().into();
+        let mut input = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+        input.ptd = core::ptr::dangling_mut();
+        let mut output = FORMATETC::default();
+
+        let result = unsafe { data_object.GetCanonicalFormatEtc(&raw const input, &raw mut output) };
+
+        assert_eq!(result, DATA_S_SAMEFORMATETC);
+        assert_eq!(output.cfFormat, input.cfFormat);
+        assert_eq!(output.dwAspect, input.dwAspect);
+        assert!(output.ptd.is_null());
+    }
+
+    #[test]
+    fn enum_format_etc_for_set_direction_returns_e_notimpl() {
+        let data_object: IDataObject = DataObject::new().into();
+
+        let err = unsafe { data_object.EnumFormatEtc(DATADIR_SET.0.cast_unsigned()) }.unwrap_err();
+
+        assert_eq!(err.code(), E_NOTIMPL);
+    }
+
+    #[test]
+    fn query_get_data_with_non_content_aspect_returns_dv_e_formatetc() {
+        let data_object = ComObject::new(DataObject::new());
+        let data = hglobal_writer::new_bytes(b"payload").unwrap();
+        assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), data));
+        let iface: IDataObject = data_object.to_interface();
+        let format_etc = FORMATETC {
+            dwAspect: DVASPECT_DOCPRINT.0,
+            ..get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT))
+        };
+
+        let result = unsafe { iface.QueryGetData(&raw const format_etc) };
+
+        assert_eq!(result, DV_E_FORMATETC);
+    }
+
+    #[test]
+    fn get_data_here_returns_e_notimpl() {
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+        let mut medium = hglobal_medium(TYMED_HGLOBAL.0, windows::Win32::Foundation::HGLOBAL::default());
+
+        let err = unsafe { data_object.GetDataHere(&raw const format_etc, &raw mut medium) }.unwrap_err();
+
+        assert_eq!(err.code(), E_NOTIMPL);
+    }
+
+    #[test]
+    fn advise_methods_report_not_supported() {
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let dadvise = unsafe { data_object.DAdvise(&raw const format_etc, 0, None::<&IAdviseSink>) }.unwrap_err();
+        let dunadvise = unsafe { data_object.DUnadvise(0) }.unwrap_err();
+        // IEnumSTATDATA is not Debug, so inspect the error without unwrap_err.
+        let enum_dadvise = unsafe { data_object.EnumDAdvise() }.err().map(|err| err.code());
+
+        assert_eq!(dadvise.code(), OLE_E_ADVISENOTSUPPORTED);
+        assert_eq!(dunadvise.code(), OLE_E_ADVISENOTSUPPORTED);
+        assert_eq!(enum_dadvise, Some(OLE_E_ADVISENOTSUPPORTED));
+    }
+
+    #[test]
+    fn is_data_object_format_available_reflects_presence() {
+        let data_object = ComObject::new(DataObject::new());
+        let data = hglobal_writer::new_bytes(b"payload").unwrap();
+        assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), data));
+        let iface: IDataObject = data_object.to_interface();
+
+        assert!(super::is_data_object_format_available(&iface, DataFormat::Other(CUSTOM_FORMAT)).unwrap());
+        assert!(!super::is_data_object_format_available(&iface, DataFormat::Other(UNKNOWN_FORMAT)).unwrap());
+    }
+
+    #[test]
+    fn set_data_with_null_medium_returns_e_pointer() {
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let err = unsafe { data_object.SetData(&raw const format_etc, core::ptr::null(), false) }.unwrap_err();
+
+        assert_eq!(err.code(), E_POINTER);
     }
 }

--- a/native/desktop-win32/src/win32/data_object.rs
+++ b/native/desktop-win32/src/win32/data_object.rs
@@ -3,26 +3,91 @@
 
 use std::mem::ManuallyDrop;
 
+use anyhow::Context;
 use windows::Win32::{
     Foundation::{
-        DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE, HGLOBAL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
+        DV_E_DVASPECT, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
     },
     System::{
         Com::{
             DATADIR, DATADIR_GET, DVASPECT_CONTENT, FORMATETC, IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
-            STGMEDIUM, STGMEDIUM_0, TYMED, TYMED_HGLOBAL, TYMED_ISTREAM,
+            IStream, STGMEDIUM, STGMEDIUM_0, TYMED, TYMED_HGLOBAL, TYMED_ISTREAM,
         },
         Ole::ReleaseStgMedium,
+        WinRT::{AGILEREFERENCE_DEFAULT, IAgileReference, RoGetAgileReference},
     },
     UI::Shell::SHCreateStdEnumFmtEtc,
 };
-use windows_core::{BOOL, Error as WinError, HRESULT, Ref as WinRef, Result as WinResult, implement};
+use windows_core::{BOOL, Error as WinError, HRESULT, Interface, Ref as WinRef, Result as WinResult, implement};
 
-use super::{data_reader::istream_reader, data_transfer::DataFormat, global_data::HGlobalData};
+use super::{data_transfer::DataFormat, global_data::HGlobalData};
+
+/// The data stored for a format, preserving its `TYMED`: an HGLOBAL's contents are copied,
+/// a stream is kept by reference.
+enum StoredMedium {
+    HGlobal(HGlobalData),
+    /// An agile reference to a stored stream: usable from any apartment and thread, unlike a raw
+    /// `IStream`, which is bound to the apartment that produced it.
+    Stream(IAgileReference),
+}
+
+// SAFETY: `HGlobalData` is `Send`/`Sync` (an HGLOBAL is process-global), and an `IAgileReference` is
+// agile by construction — it may be held, resolved, and released from any apartment/thread, which
+// `papaya`'s deferred reclamation may do on a thread other than the one that stored it. windows-core
+// does not express agility in the type system, so the marker traits are asserted here.
+#[expect(
+    clippy::non_send_fields_in_send_ty,
+    reason = "IAgileReference is agile: cross-thread hold/resolve/release is sound (see SAFETY above)"
+)]
+unsafe impl Send for StoredMedium {}
+unsafe impl Sync for StoredMedium {}
+
+impl StoredMedium {
+    const fn tymed(&self) -> u32 {
+        match self {
+            Self::HGlobal(_) => TYMED_HGLOBAL.0.cast_unsigned(),
+            Self::Stream(_) => TYMED_ISTREAM.0.cast_unsigned(),
+        }
+    }
+
+    /// The `HRESULT` a `GetData`/`QueryGetData` for `format_etc` yields once its `cfFormat` matches
+    /// this entry: `DV_E_DVASPECT` for an unsupported aspect, `DV_E_TYMED` when the requested medium
+    /// excludes the one stored, otherwise `S_OK`.
+    const fn query(&self, format_etc: &FORMATETC) -> HRESULT {
+        if format_etc.dwAspect != DVASPECT_CONTENT.0 {
+            DV_E_DVASPECT
+        } else if (format_etc.tymed & self.tymed()) == 0 {
+            DV_E_TYMED
+        } else {
+            S_OK
+        }
+    }
+
+    /// Produces an owned `STGMEDIUM` for the caller to free via `ReleaseStgMedium`.
+    fn duplicate(&self) -> WinResult<STGMEDIUM> {
+        match self {
+            Self::HGlobal(data) => Ok(STGMEDIUM {
+                tymed: TYMED_HGLOBAL.0.cast_unsigned(),
+                u: STGMEDIUM_0 { hGlobal: data.copied()? },
+                pUnkForRelease: ManuallyDrop::new(None),
+            }),
+            Self::Stream(agile) => {
+                let stream: IStream = unsafe { agile.Resolve() }?;
+                Ok(STGMEDIUM {
+                    tymed: TYMED_ISTREAM.0.cast_unsigned(),
+                    u: STGMEDIUM_0 {
+                        pstm: ManuallyDrop::new(Some(stream)),
+                    },
+                    pUnkForRelease: ManuallyDrop::new(None),
+                })
+            }
+        }
+    }
+}
 
 #[implement(IDataObject)]
 pub struct DataObject {
-    hash_map: papaya::HashMap<u32, HGlobalData>,
+    hash_map: papaya::HashMap<u32, StoredMedium>,
 }
 
 impl DataObject {
@@ -35,22 +100,10 @@ impl DataObject {
     }
 
     pub fn add_format(&self, data_format: DataFormat, data: HGlobalData) -> bool {
-        self.hash_map.pin().try_insert(data_format.id(), data).is_ok()
-    }
-
-    fn is_format_supported(&self, format_etc: &FORMATETC) -> bool {
-        self.hash_map.pin().contains_key(&u32::from(format_etc.cfFormat))
-            && format_etc.dwAspect == DVASPECT_CONTENT.0
-            && (format_etc.tymed & TYMED_HGLOBAL.0.cast_unsigned()) != 0
-    }
-
-    #[inline]
-    fn get_content(&self, format_id: u32) -> WinResult<HGLOBAL> {
         self.hash_map
             .pin()
-            .get(&format_id)
-            .ok_or_else(|| DV_E_FORMATETC.into())
-            .and_then(HGlobalData::copied)
+            .try_insert(data_format.id(), StoredMedium::HGlobal(data))
+            .is_ok()
     }
 }
 
@@ -59,16 +112,12 @@ impl IDataObject_Impl for DataObject_Impl {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn GetData(&self, format_etc_in: *const FORMATETC) -> WinResult<STGMEDIUM> {
         let format_etc = unsafe { format_etc_in.as_ref() }.ok_or_else(|| WinError::from(E_POINTER))?;
-        if !self.is_format_supported(format_etc) {
-            return Err(DV_E_FORMATETC.into());
-        }
-        let content = self.get_content(u32::from(format_etc.cfFormat))?;
-        let medium = STGMEDIUM {
-            tymed: TYMED_HGLOBAL.0.cast_unsigned(),
-            u: STGMEDIUM_0 { hGlobal: content },
-            pUnkForRelease: ManuallyDrop::new(None),
-        };
-        Ok(medium)
+        let map = self.hash_map.pin();
+        let stored = map
+            .get(&u32::from(format_etc.cfFormat))
+            .ok_or_else(|| WinError::from(DV_E_FORMATETC))?;
+        stored.query(format_etc).ok()?;
+        stored.duplicate()
     }
 
     fn GetDataHere(&self, _format_etc: *const FORMATETC, _medium: *mut STGMEDIUM) -> WinResult<()> {
@@ -78,10 +127,12 @@ impl IDataObject_Impl for DataObject_Impl {
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn QueryGetData(&self, format_etc_in: *const FORMATETC) -> HRESULT {
-        match unsafe { format_etc_in.as_ref() } {
-            Some(format_etc) if self.is_format_supported(format_etc) => S_OK,
-            Some(_) => DV_E_FORMATETC,
-            None => E_POINTER,
+        let Some(format_etc) = (unsafe { format_etc_in.as_ref() }) else {
+            return E_POINTER;
+        };
+        match self.hash_map.pin().get(&u32::from(format_etc.cfFormat)) {
+            Some(stored) => stored.query(format_etc),
+            None => DV_E_FORMATETC,
         }
     }
 
@@ -104,13 +155,14 @@ impl IDataObject_Impl for DataObject_Impl {
         // Borrow the medium mutably so one reference both reads its fields and releases it in place
         // on fRelease. The SetData C ABI passes a non-const STGMEDIUM*, modeled here as *const.
         let medium = unsafe { medium_in.cast_mut().as_mut() }.ok_or_else(|| WinError::from(E_POINTER))?;
-        // The drag-image helper stores its private formats as both HGLOBAL and ISTREAM. Normalize
-        // either into an owned HGLOBAL copy so the rest of the data object only handles HGLOBAL; for
-        // an ISTREAM the bytes are read out and copied, never the live stream retained.
-        let medium_data: anyhow::Result<HGlobalData> = match TYMED(medium.tymed.cast_signed()) {
-            TYMED_HGLOBAL => HGlobalData::copy_from(HANDLE(unsafe { medium.u.hGlobal }.0)),
+        // Keep the medium's TYMED so GetData returns the format the way it was set: copy an HGLOBAL's
+        // contents, hold a stream by agile reference. Other tymeds are unsupported.
+        let medium_data: anyhow::Result<StoredMedium> = match TYMED(medium.tymed.cast_signed()) {
+            TYMED_HGLOBAL => HGlobalData::copy_from(HANDLE(unsafe { medium.u.hGlobal }.0)).map(StoredMedium::HGlobal),
             TYMED_ISTREAM => match unsafe { (*medium.u.pstm).as_ref() } {
-                Some(stream) => istream_reader::get_bytes(stream).and_then(|bytes| HGlobalData::alloc_from(&bytes)),
+                Some(stream) => unsafe { RoGetAgileReference(AGILEREFERENCE_DEFAULT, &IStream::IID, stream) }
+                    .map(StoredMedium::Stream)
+                    .context("failed to create an agile reference to the IStream"),
                 None => Err(anyhow::anyhow!("data object received a null IStream")),
             },
             _ => return Err(DV_E_TYMED.into()),
@@ -125,7 +177,8 @@ impl IDataObject_Impl for DataObject_Impl {
         })?;
         // SetData replaces any existing data for the format, per the IDataObject contract.
         self.hash_map.pin().insert(u32::from(format_etc.cfFormat), data);
-        // fRelease == TRUE hands the medium's ownership to us; free it now that the bytes are copied.
+        // fRelease == TRUE hands the medium's ownership to us; free it now that we hold our own
+        // copy (HGLOBAL) or agile reference (stream).
         if release.as_bool() {
             unsafe { ReleaseStgMedium(medium) };
         }
@@ -138,8 +191,8 @@ impl IDataObject_Impl for DataObject_Impl {
                 let formats = self
                     .hash_map
                     .pin()
-                    .keys()
-                    .map(|k| get_format_etc_for_hglobal(DataFormat::Other(*k)))
+                    .iter()
+                    .map(|(cf_format, stored)| get_format_etc(*cf_format, stored.tymed()))
                     .collect::<Vec<_>>();
                 unsafe { SHCreateStdEnumFmtEtc(&formats) }
             }
@@ -161,7 +214,7 @@ impl IDataObject_Impl for DataObject_Impl {
 }
 
 pub fn is_data_object_format_available(data_object: &IDataObject, data_format: DataFormat) -> anyhow::Result<bool> {
-    let format_etc = get_format_etc_for_hglobal(data_format);
+    let format_etc = get_format_etc_for_supported_tymeds(data_format);
     match unsafe { data_object.QueryGetData(&raw const format_etc) } {
         S_OK => Ok(true),
         S_FALSE | DV_E_FORMATETC | DV_E_TYMED => Ok(false),
@@ -185,17 +238,24 @@ pub fn enum_data_object_format_ids(data_object: &IDataObject) -> anyhow::Result<
     Ok(hash_set.into_iter().collect())
 }
 
+/// Returns a `FORMATETC` requesting `data_format` in any `TYMED` the data-transfer path handles —
+/// HGLOBAL or ISTREAM, the media this object stores and the reader consumes.
 #[inline]
-fn get_format_etc_for_hglobal(data_format: DataFormat) -> FORMATETC {
+pub(crate) fn get_format_etc_for_supported_tymeds(data_format: DataFormat) -> FORMATETC {
+    get_format_etc(data_format.id(), (TYMED_HGLOBAL.0 | TYMED_ISTREAM.0).cast_unsigned())
+}
+
+#[inline]
+const fn get_format_etc(cf_format: u32, tymed: u32) -> FORMATETC {
     FORMATETC {
         // Registered clipboard formats are identified by values in the range 0xC000 through 0xFFFF.
         // See: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerclipboardformatw
         #[allow(clippy::cast_possible_truncation)]
-        cfFormat: data_format.id() as u16,
+        cfFormat: cf_format as u16,
         ptd: core::ptr::null_mut(),
         dwAspect: DVASPECT_CONTENT.0,
         lindex: -1,
-        tymed: TYMED_HGLOBAL.0.cast_unsigned(),
+        tymed,
     }
 }
 
@@ -204,20 +264,34 @@ mod tests {
     use std::mem::ManuallyDrop;
 
     use windows::Win32::{
-        Foundation::{DATA_S_SAMEFORMATETC, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_OK},
+        Foundation::{
+            DATA_S_SAMEFORMATETC, DV_E_DVASPECT, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE,
+            OLE_E_ADVISENOTSUPPORTED, RPC_E_CHANGED_MODE, S_FALSE, S_OK,
+        },
         System::Com::{
-            DATADIR_SET, DVASPECT_DOCPRINT, FORMATETC, IAdviseSink, IDataObject, STGMEDIUM, STGMEDIUM_0, TYMED_GDI, TYMED_HGLOBAL,
-            TYMED_ISTREAM,
+            COINIT_APARTMENTTHREADED, CoInitializeEx, DATADIR_GET, DATADIR_SET, DVASPECT_DOCPRINT, FORMATETC, IAdviseSink, IDataObject,
+            STGMEDIUM, STGMEDIUM_0, TYMED_GDI, TYMED_HGLOBAL, TYMED_ISTREAM,
         },
         UI::Shell::SHCreateMemStream,
     };
     use windows_core::ComObject;
 
-    use super::{DataFormat, DataObject, get_format_etc_for_hglobal};
+    use super::{DataFormat, DataObject, get_format_etc};
+    use crate::win32::data_reader::istream_reader;
     use crate::win32::global_data::{HGlobalData, hglobal_reader, hglobal_writer};
 
     const CUSTOM_FORMAT: u32 = 0xC123;
     const UNKNOWN_FORMAT: u32 = 0xC456;
+
+    fn ensure_com_initialized() {
+        // RoGetAgileReference needs COM initialized on the calling thread: initialize an STA and
+        // tolerate the "already initialized" returns for repeated tests on one thread.
+        let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        assert!(
+            hr.is_ok() || hr == S_FALSE || hr == RPC_E_CHANGED_MODE,
+            "CoInitializeEx failed: {hr:?}"
+        );
+    }
 
     fn hglobal_medium(tymed: i32, hglobal: windows::Win32::Foundation::HGLOBAL) -> STGMEDIUM {
         STGMEDIUM {
@@ -227,11 +301,32 @@ mod tests {
         }
     }
 
+    #[inline]
+    fn get_format_etc_for_hglobal(data_format: DataFormat) -> FORMATETC {
+        get_format_etc(data_format.id(), TYMED_HGLOBAL.0.cast_unsigned())
+    }
+
     fn read_get_data_bytes(data_object: &IDataObject, format_id: u32) -> Vec<u8> {
         let format_etc = get_format_etc_for_hglobal(DataFormat::Other(format_id));
         let medium = unsafe { data_object.GetData(&raw const format_etc) }.unwrap();
         let copied = HGlobalData::copy_from(HANDLE(unsafe { medium.u.hGlobal }.0)).unwrap();
         hglobal_reader::get_bytes(&copied).unwrap()
+    }
+
+    /// Stores `payload` as a `TYMED_ISTREAM` medium under `format_id`, with `fRelease == TRUE` so the
+    /// data object takes the stream. Initializes COM because `SetData` calls `RoGetAgileReference`.
+    fn set_istream_format(data_object: &IDataObject, format_id: u32, payload: &[u8]) {
+        ensure_com_initialized();
+        let stream = unsafe { SHCreateMemStream(Some(payload)) }.expect("SHCreateMemStream returned null");
+        let medium = STGMEDIUM {
+            tymed: TYMED_ISTREAM.0.cast_unsigned(),
+            u: STGMEDIUM_0 {
+                pstm: ManuallyDrop::new(Some(stream)),
+            },
+            pUnkForRelease: ManuallyDrop::new(None),
+        };
+        let format_etc = get_format_etc(format_id, TYMED_ISTREAM.0.cast_unsigned());
+        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, true) }.unwrap();
     }
 
     #[test]
@@ -285,25 +380,25 @@ mod tests {
     }
 
     #[test]
-    fn set_data_with_istream_copies_bytes_to_hglobal() {
-        // The drag-image helper sets a TYMED_ISTREAM private format; the data object must read its
-        // bytes and serve them back as HGLOBAL.
+    fn set_data_with_istream_roundtrips_as_stream() {
+        // A format set as TYMED_ISTREAM is retained by reference and served back as a stream, not
+        // flattened to HGLOBAL.
         let payload: &[u8] = b"istream-drag-context";
-        let stream = unsafe { SHCreateMemStream(Some(payload)) }.expect("SHCreateMemStream returned null");
-        let medium = STGMEDIUM {
-            tymed: TYMED_ISTREAM.0.cast_unsigned(),
-            u: STGMEDIUM_0 {
-                pstm: ManuallyDrop::new(Some(stream)),
-            },
-            pUnkForRelease: ManuallyDrop::new(None),
-        };
         let data_object: IDataObject = DataObject::new().into();
-        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+        set_istream_format(&data_object, CUSTOM_FORMAT, payload);
+        let format_etc = get_format_etc(CUSTOM_FORMAT, TYMED_ISTREAM.0.cast_unsigned());
 
-        // fRelease == TRUE: SetData reads the stream's bytes, then releases the stream.
-        unsafe { data_object.SetData(&raw const format_etc, &raw const medium, true) }.unwrap();
+        // GetData serves the format back as a stream; ReleaseStgMedium frees the returned copy.
+        let mut out = unsafe { data_object.GetData(&raw const format_etc) }.unwrap();
+        assert_eq!(
+            out.tymed,
+            TYMED_ISTREAM.0.cast_unsigned(),
+            "an ISTREAM format must be served back as a stream"
+        );
+        let bytes = istream_reader::get_bytes(unsafe { (*out.u.pstm).as_ref() }.expect("stream medium")).unwrap();
+        unsafe { windows::Win32::System::Ole::ReleaseStgMedium(&raw mut out) };
 
-        assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), payload.to_vec());
+        assert_eq!(bytes, payload);
     }
 
     #[test]
@@ -392,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    fn query_get_data_with_non_content_aspect_returns_dv_e_formatetc() {
+    fn query_get_data_with_non_content_aspect_returns_dv_e_dvaspect() {
         let data_object = ComObject::new(DataObject::new());
         let data = hglobal_writer::new_bytes(b"payload").unwrap();
         assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), data));
@@ -404,7 +499,7 @@ mod tests {
 
         let result = unsafe { iface.QueryGetData(&raw const format_etc) };
 
-        assert_eq!(result, DV_E_FORMATETC);
+        assert_eq!(result, DV_E_DVASPECT);
     }
 
     #[test]
@@ -452,5 +547,106 @@ mod tests {
         let err = unsafe { data_object.SetData(&raw const format_etc, core::ptr::null(), false) }.unwrap_err();
 
         assert_eq!(err.code(), E_POINTER);
+    }
+
+    #[test]
+    fn set_data_replaces_existing_format() {
+        // SetData overwrites an existing format, unlike add_format, which keeps the first value.
+        let first = hglobal_writer::new_bytes(b"first").unwrap();
+        let second = hglobal_writer::new_bytes(b"second").unwrap();
+        let data_object: IDataObject = DataObject::new().into();
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let first_medium = hglobal_medium(TYMED_HGLOBAL.0, first.as_raw());
+        unsafe { data_object.SetData(&raw const format_etc, &raw const first_medium, false) }.unwrap();
+        let second_medium = hglobal_medium(TYMED_HGLOBAL.0, second.as_raw());
+        unsafe { data_object.SetData(&raw const format_etc, &raw const second_medium, false) }.unwrap();
+
+        assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), b"second");
+    }
+
+    #[test]
+    fn is_data_object_format_available_true_for_stream_format() {
+        // The availability query spans HGLOBAL and ISTREAM, so a stream-only format reads as present.
+        let data_object: IDataObject = DataObject::new().into();
+        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
+
+        assert!(super::is_data_object_format_available(&data_object, DataFormat::Other(CUSTOM_FORMAT)).unwrap());
+    }
+
+    #[test]
+    fn query_get_data_returns_s_ok_for_stream_format() {
+        let data_object: IDataObject = DataObject::new().into();
+        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
+        let format_etc = get_format_etc(CUSTOM_FORMAT, TYMED_ISTREAM.0.cast_unsigned());
+
+        let result = unsafe { data_object.QueryGetData(&raw const format_etc) };
+
+        assert_eq!(result, S_OK);
+    }
+
+    #[test]
+    fn enum_format_etc_advertises_stream_tymed() {
+        // EnumFormatEtc reports each format with the TYMED it was stored under, so a stream format is
+        // advertised as TYMED_ISTREAM rather than the default HGLOBAL.
+        let data_object: IDataObject = DataObject::new().into();
+        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
+
+        let iter = unsafe { data_object.EnumFormatEtc(DATADIR_GET.0.cast_unsigned()) }.unwrap();
+        let mut formats = [FORMATETC::default(); 1];
+        let mut enumerated = None;
+        while S_OK == unsafe { iter.Next(&mut formats, None) } {
+            if u32::from(formats[0].cfFormat) == CUSTOM_FORMAT {
+                enumerated = Some(formats[0]);
+            }
+        }
+
+        assert_eq!(
+            enumerated.expect("format was enumerated").tymed,
+            TYMED_ISTREAM.0.cast_unsigned(),
+            "a stream format must be advertised as TYMED_ISTREAM"
+        );
+    }
+
+    #[test]
+    fn get_data_with_mismatched_tymed_returns_dv_e_tymed() {
+        // A format stored only as a stream, requested HGLOBAL-only, is present but in the wrong
+        // medium — DV_E_TYMED, not the DV_E_FORMATETC reserved for an unknown format.
+        let data_object: IDataObject = DataObject::new().into();
+        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let code = unsafe { data_object.GetData(&raw const format_etc) }.err().map(|err| err.code());
+
+        assert_eq!(code, Some(DV_E_TYMED));
+    }
+
+    #[test]
+    fn query_get_data_with_mismatched_tymed_returns_dv_e_tymed() {
+        let data_object: IDataObject = DataObject::new().into();
+        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
+        let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
+
+        let result = unsafe { data_object.QueryGetData(&raw const format_etc) };
+
+        assert_eq!(result, DV_E_TYMED);
+    }
+
+    #[test]
+    fn set_data_with_null_istream_returns_error() {
+        // A TYMED_ISTREAM medium carrying a null stream is rejected, not dereferenced.
+        let data_object: IDataObject = DataObject::new().into();
+        let medium = STGMEDIUM {
+            tymed: TYMED_ISTREAM.0.cast_unsigned(),
+            u: STGMEDIUM_0 {
+                pstm: ManuallyDrop::new(None),
+            },
+            pUnkForRelease: ManuallyDrop::new(None),
+        };
+        let format_etc = get_format_etc(CUSTOM_FORMAT, TYMED_ISTREAM.0.cast_unsigned());
+
+        let err = unsafe { data_object.SetData(&raw const format_etc, &raw const medium, false) }.unwrap_err();
+
+        assert_eq!(err.code(), E_UNEXPECTED);
     }
 }

--- a/native/desktop-win32/src/win32/data_reader.rs
+++ b/native/desktop-win32/src/win32/data_reader.rs
@@ -4,13 +4,14 @@ use anyhow::Context;
 use windows::Win32::{
     Foundation::{DV_E_TYMED, E_POINTER, HANDLE},
     System::{
-        Com::{DVASPECT_CONTENT, FORMATETC, IDataObject, IStream, STGMEDIUM, TYMED, TYMED_HGLOBAL, TYMED_ISTREAM},
+        Com::{IDataObject, IStream, STGMEDIUM, TYMED, TYMED_HGLOBAL, TYMED_ISTREAM},
         Ole::ReleaseStgMedium,
     },
 };
 use windows_core::Error as WinError;
 
 use super::{
+    data_object::get_format_etc_for_supported_tymeds,
     data_transfer::DataFormat,
     global_data::{HGlobalData, hglobal_reader},
 };
@@ -38,13 +39,7 @@ pub struct DataReader {
 
 impl DataReader {
     pub fn create(data_object: &IDataObject, data_format: DataFormat) -> anyhow::Result<Self> {
-        let format_desc = FORMATETC {
-            cfFormat: data_format.id().try_into()?,
-            ptd: core::ptr::null_mut(),
-            dwAspect: DVASPECT_CONTENT.0,
-            lindex: -1,
-            tymed: (TYMED_HGLOBAL.0 | TYMED_ISTREAM.0).cast_unsigned(),
-        };
+        let format_desc = get_format_etc_for_supported_tymeds(data_format);
         let medium = unsafe { data_object.GetData(&raw const format_desc)? };
         let guard = StgMediumGuard { medium };
         let source = match TYMED(guard.medium.tymed.cast_signed()) {

--- a/native/desktop-win32/src/win32/drag_drop.rs
+++ b/native/desktop-win32/src/win32/drag_drop.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::ref_as_ptr)]
 
 use windows::Win32::{
-    Foundation::{E_POINTER, POINTL},
+    Foundation::{COLORREF, E_POINTER, POINT, POINTL, SIZE},
     System::{
         Com::IDataObject,
         Ole::{
@@ -11,10 +11,11 @@ use windows::Win32::{
         },
         SystemServices::MODIFIERKEYS_FLAGS,
     },
+    UI::{Controls::CLR_NONE, Shell::SHDRAGIMAGE},
 };
 use windows_core::{BOOL, HRESULT, Ref as WinRef, Result as WinResult, implement};
 
-use super::{com::ComInterfaceRawPtr, geometry::PhysicalPoint, window::Window};
+use super::{com::ComInterfaceRawPtr, geometry::PhysicalPoint, wic_image::WicBitmap, window::Window};
 
 #[allow(clippy::struct_field_names)]
 #[repr(C)]
@@ -47,6 +48,27 @@ pub fn start_drag_drop(data_object: &IDataObject, allowed_effects: u32, callback
 pub fn revoke_drop_target(window: &Window) -> anyhow::Result<()> {
     unsafe { RevokeDragDrop(window.hwnd())? };
     Ok(())
+}
+
+// Builds the `SHDRAGIMAGE` for a source-initiated drag from an encoded image (PNG, JPEG, …). The
+// caller owns the returned `hbmpDragImage` and must free it once the drag-image helper is done.
+#[expect(dead_code, reason = "entry point for source-initiated drag images; not yet wired into a drag")]
+pub(crate) fn create_drag_image(image_bytes: &[u8], cursor_offset: PhysicalPoint) -> anyhow::Result<SHDRAGIMAGE> {
+    let image = WicBitmap::decode_from_bytes(image_bytes)?;
+    let size = image.size();
+    Ok(SHDRAGIMAGE {
+        sizeDragImage: SIZE {
+            cx: size.width.0,
+            cy: size.height.0,
+        },
+        ptOffset: POINT {
+            x: cursor_offset.x.0,
+            y: cursor_offset.y.0,
+        },
+        hbmpDragImage: image.into_handle(),
+        // No color key; the DIB uses per-pixel alpha.
+        crColorKey: COLORREF(CLR_NONE.cast_unsigned()),
+    })
 }
 
 #[repr(u32)]

--- a/native/desktop-win32/src/win32/drag_drop.rs
+++ b/native/desktop-win32/src/win32/drag_drop.rs
@@ -1,17 +1,22 @@
 #![allow(clippy::inline_always)]
 #![allow(clippy::ref_as_ptr)]
 
+use anyhow::Context;
 use windows::Win32::{
     Foundation::{COLORREF, E_POINTER, POINT, POINTL, SIZE},
+    Graphics::Gdi::{DeleteObject, HGDIOBJ},
     System::{
-        Com::IDataObject,
+        Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, IDataObject},
         Ole::{
             DROPEFFECT, DROPEFFECT_NONE, DoDragDrop, IDropSource, IDropSource_Impl, IDropTarget, IDropTarget_Impl, RegisterDragDrop,
             RevokeDragDrop,
         },
         SystemServices::MODIFIERKEYS_FLAGS,
     },
-    UI::{Controls::CLR_NONE, Shell::SHDRAGIMAGE},
+    UI::{
+        Controls::CLR_NONE,
+        Shell::{CLSID_DragDropHelper, IDragSourceHelper, SHDRAGIMAGE},
+    },
 };
 use windows_core::{BOOL, HRESULT, Ref as WinRef, Result as WinResult, implement};
 
@@ -38,7 +43,25 @@ pub fn register_drop_target(window: &Window, callbacks: DropTargetCallbacks) -> 
     Ok(())
 }
 
-pub fn start_drag_drop(data_object: &IDataObject, allowed_effects: u32, callbacks: DragSourceCallbacks) -> anyhow::Result<u32> {
+pub fn start_drag_drop(
+    data_object: &IDataObject,
+    allowed_effects: u32,
+    drag_image: Option<(&[u8], PhysicalPoint)>,
+    callbacks: DragSourceCallbacks,
+) -> anyhow::Result<u32> {
+    if let Some((image_bytes, cursor_offset)) = drag_image {
+        // Create the helper before decoding the image: until create_drag_image runs there is no
+        // bitmap to clean up, so a helper-creation failure here leaks nothing.
+        let helper: IDragSourceHelper =
+            unsafe { CoCreateInstance(&CLSID_DragDropHelper, None, CLSCTX_INPROC_SERVER) }.context("create drag-drop helper")?;
+        let shdi = create_drag_image(image_bytes, cursor_offset)?;
+        // InitializeFromBitmap takes ownership of shdi.hbmpDragImage on success; on failure the helper
+        // does not take it, so free it here. This is the only manual cleanup point for the bitmap.
+        if let Err(err) = unsafe { helper.InitializeFromBitmap(&raw const shdi, data_object) } {
+            let _ = unsafe { DeleteObject(HGDIOBJ(shdi.hbmpDragImage.0)) };
+            anyhow::bail!("failed to initialize drag image: {err}");
+        }
+    }
     let source: IDropSource = DragSource { callbacks }.into();
     let mut effect = DROPEFFECT_NONE;
     unsafe { DoDragDrop(data_object, &source, DROPEFFECT(allowed_effects), &raw mut effect).ok()? };
@@ -52,7 +75,6 @@ pub fn revoke_drop_target(window: &Window) -> anyhow::Result<()> {
 
 // Builds the `SHDRAGIMAGE` for a source-initiated drag from an encoded image (PNG, JPEG, …). The
 // caller owns the returned `hbmpDragImage` and must free it once the drag-image helper is done.
-#[expect(dead_code, reason = "entry point for source-initiated drag images; not yet wired into a drag")]
 pub(crate) fn create_drag_image(image_bytes: &[u8], cursor_offset: PhysicalPoint) -> anyhow::Result<SHDRAGIMAGE> {
     let image = WicBitmap::decode_from_bytes(image_bytes)?;
     let size = image.size();
@@ -141,5 +163,68 @@ impl IDropTarget_Impl for DropTarget_Impl {
         let result = (self.callbacks.drop_handler)(data_obj_ptr, key_state.0, PhysicalPoint::new(pt.x, pt.y), effect.0);
         *effect = DROPEFFECT(result);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::win32::data_object::DataObject;
+    use windows::Win32::{
+        Foundation::{RPC_E_CHANGED_MODE, S_FALSE},
+        System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx},
+    };
+
+    // 3x2 (non-square) RGBA PNG the Shell helper can decode. Non-square so a width/height
+    // transposition in the SHDRAGIMAGE size is observable.
+    const TEST_PNG_3X2: [u8; 74] = [
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+        0x00, 0x02, 0x08, 0x06, 0x00, 0x00, 0x00, 0x9d, 0x74, 0x66, 0x1a, 0x00, 0x00, 0x00, 0x11, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63,
+        0xf8, 0xcf, 0xc0, 0xf0, 0x1f, 0x86, 0x19, 0x90, 0x39, 0x00, 0x9b, 0x7e, 0x0b, 0xf5, 0x72, 0xb0, 0xb9, 0x3c, 0x00, 0x00, 0x00, 0x00,
+        0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    fn ensure_com_initialized() {
+        // The Shell drag-drop helper is an STA in-proc object; creating it from an MTA thread fails
+        // to find a cross-apartment proxy (E_NOINTERFACE). Match production (application.rs calls
+        // OleInitialize, which is STA) by initializing this thread as an STA. Cargo unit tests have
+        // no OleInitialize of their own; tolerate the "already initialized" returns.
+        let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        assert!(
+            hr.is_ok() || hr == S_FALSE || hr == RPC_E_CHANGED_MODE,
+            "CoInitializeEx failed: {hr:?}"
+        );
+    }
+
+    // The drag-image helper requires the data object to accept its private formats (stored via
+    // IDataObject::SetData) and a valid SHDRAGIMAGE bitmap; this checks that InitializeFromBitmap
+    // succeeds against our data object and a decoded image. On success the helper owns
+    // shdi.hbmpDragImage, so it is NOT freed here; the single handle lives until the test process
+    // exits, which is acceptable.
+    #[test]
+    fn initialize_from_bitmap_accepts_our_data_object() {
+        ensure_com_initialized();
+        let data_object: IDataObject = DataObject::new().into();
+        let helper: IDragSourceHelper =
+            unsafe { CoCreateInstance(&CLSID_DragDropHelper, None, CLSCTX_INPROC_SERVER) }.expect("create drag-drop helper");
+        let shdi = create_drag_image(&TEST_PNG_3X2, PhysicalPoint::new(0, 0)).expect("create drag image");
+        let result = unsafe { helper.InitializeFromBitmap(&raw const shdi, &data_object) };
+        assert!(result.is_ok(), "InitializeFromBitmap failed: {result:?}");
+    }
+
+    // create_drag_image maps the decoded size into SHDRAGIMAGE.sizeDragImage and the cursor offset
+    // into ptOffset. The asymmetric offset (x != y) catches an x/y swap; the non-square 3x2 image
+    // catches a width/height transposition.
+    #[test]
+    fn create_drag_image_maps_offset_and_size() {
+        ensure_com_initialized();
+        let image = create_drag_image(&TEST_PNG_3X2, PhysicalPoint::new(7, 11)).expect("create drag image");
+        let offset = (image.ptOffset.x, image.ptOffset.y);
+        let size = (image.sizeDragImage.cx, image.sizeDragImage.cy);
+        // This layer owns the raw HBITMAP; free it once the fields are read.
+        let deleted = unsafe { DeleteObject(HGDIOBJ(image.hbmpDragImage.0)) };
+        assert!(deleted.as_bool(), "failed to delete drag-image bitmap");
+        assert_eq!(offset, (7, 11), "ptOffset must mirror the cursor offset");
+        assert_eq!(size, (3, 2), "sizeDragImage must be (width, height), not transposed");
     }
 }

--- a/native/desktop-win32/src/win32/drag_drop.rs
+++ b/native/desktop-win32/src/win32/drag_drop.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context;
 use windows::Win32::{
-    Foundation::{COLORREF, E_POINTER, POINT, POINTL, SIZE},
+    Foundation::{COLORREF, E_POINTER, HWND, POINT, POINTL, SIZE},
     Graphics::Gdi::{DeleteObject, HGDIOBJ},
     System::{
         Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, IDataObject},
@@ -15,7 +15,7 @@ use windows::Win32::{
     },
     UI::{
         Controls::CLR_NONE,
-        Shell::{CLSID_DragDropHelper, IDragSourceHelper, SHDRAGIMAGE},
+        Shell::{CLSID_DragDropHelper, IDragSourceHelper, IDropTargetHelper, SHDRAGIMAGE},
     },
 };
 use windows_core::{BOOL, HRESULT, Ref as WinRef, Result as WinResult, implement};
@@ -38,7 +38,17 @@ pub struct DragSourceCallbacks {
 }
 
 pub fn register_drop_target(window: &Window, callbacks: DropTargetCallbacks) -> anyhow::Result<()> {
-    let target: IDropTarget = DropTarget { callbacks }.into();
+    // The drag-image helper lets the Shell render the OS drag image over our window. It is purely
+    // cosmetic, so a creation failure leaves `None` and the drop still works.
+    let helper: Option<IDropTargetHelper> = unsafe { CoCreateInstance(&CLSID_DragDropHelper, None, CLSCTX_INPROC_SERVER) }
+        .inspect_err(|err| log::warn!("drop-target drag-image helper unavailable: {err}"))
+        .ok();
+    let target: IDropTarget = DropTarget {
+        callbacks,
+        helper,
+        hwnd: window.hwnd(),
+    }
+    .into();
     unsafe { RegisterDragDrop(window.hwnd(), &target)? };
     Ok(())
 }
@@ -124,6 +134,8 @@ impl IDropSource_Impl for DragSource_Impl {
 #[implement(IDropTarget)]
 pub struct DropTarget {
     callbacks: DropTargetCallbacks,
+    helper: Option<IDropTargetHelper>,
+    hwnd: HWND,
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -140,6 +152,11 @@ impl IDropTarget_Impl for DropTarget_Impl {
         let data_object = data_obj.as_ref().ok_or(E_POINTER)?;
         let data_obj_ptr = ComInterfaceRawPtr::from_interface(data_object)?;
         let result = (self.callbacks.drag_enter_handler)(data_obj_ptr, key_state.0, PhysicalPoint::new(pt.x, pt.y), effect.0);
+        if let Some(helper) = &self.helper {
+            let point = POINT { x: pt.x, y: pt.y };
+            // Cosmetic only: ignore helper errors so the app's resolved effect is what we return.
+            let _ = unsafe { helper.DragEnter(self.hwnd, data_object, &raw const point, DROPEFFECT(result)) };
+        }
         *effect = DROPEFFECT(result);
         Ok(())
     }
@@ -147,12 +164,21 @@ impl IDropTarget_Impl for DropTarget_Impl {
     fn DragOver(&self, key_state: MODIFIERKEYS_FLAGS, pt: &POINTL, effect: *mut DROPEFFECT) -> WinResult<()> {
         let effect = unsafe { effect.as_mut() }.ok_or(E_POINTER)?;
         let result = (self.callbacks.drag_over_handler)(key_state.0, PhysicalPoint::new(pt.x, pt.y), effect.0);
+        if let Some(helper) = &self.helper {
+            let point = POINT { x: pt.x, y: pt.y };
+            // Cosmetic only: ignore helper errors so the app's resolved effect is what we return.
+            let _ = unsafe { helper.DragOver(&raw const point, DROPEFFECT(result)) };
+        }
         *effect = DROPEFFECT(result);
         Ok(())
     }
 
     fn DragLeave(&self) -> WinResult<()> {
         (self.callbacks.drag_leave_handler)();
+        if let Some(helper) = &self.helper {
+            // Cosmetic only: ignore helper errors.
+            let _ = unsafe { helper.DragLeave() };
+        }
         Ok(())
     }
 
@@ -161,6 +187,11 @@ impl IDropTarget_Impl for DropTarget_Impl {
         let data_object = data_obj.as_ref().ok_or(E_POINTER)?;
         let data_obj_ptr = ComInterfaceRawPtr::from_interface(data_object)?;
         let result = (self.callbacks.drop_handler)(data_obj_ptr, key_state.0, PhysicalPoint::new(pt.x, pt.y), effect.0);
+        if let Some(helper) = &self.helper {
+            let point = POINT { x: pt.x, y: pt.y };
+            // Cosmetic only: ignore helper errors so the app's resolved effect is what we return.
+            let _ = unsafe { helper.Drop(data_object, &raw const point, DROPEFFECT(result)) };
+        }
         *effect = DROPEFFECT(result);
         Ok(())
     }

--- a/native/desktop-win32/src/win32/drag_drop.rs
+++ b/native/desktop-win32/src/win32/drag_drop.rs
@@ -15,7 +15,7 @@ use windows::Win32::{
     },
     UI::{
         Controls::CLR_NONE,
-        Shell::{CLSID_DragDropHelper, IDragSourceHelper, IDropTargetHelper, SHDRAGIMAGE},
+        Shell::{CLSID_DragDropHelper, DSH_ALLOWDROPDESCRIPTIONTEXT, IDragSourceHelper2, IDropTargetHelper, SHDRAGIMAGE},
     },
 };
 use windows_core::{BOOL, HRESULT, Ref as WinRef, Result as WinResult, implement};
@@ -62,8 +62,11 @@ pub fn start_drag_drop(
     if let Some((image_bytes, cursor_offset)) = drag_image {
         // Create the helper before decoding the image: until create_drag_image runs there is no
         // bitmap to clean up, so a helper-creation failure here leaks nothing.
-        let helper: IDragSourceHelper =
+        let helper: IDragSourceHelper2 =
             unsafe { CoCreateInstance(&CLSID_DragDropHelper, None, CLSCTX_INPROC_SERVER) }.context("create drag-drop helper")?;
+        // Let a drop target's drop-description text render over our image. Cosmetic, so a failure must
+        // not abort the drag; must be set before InitializeFromBitmap to take effect.
+        let _ = unsafe { helper.SetFlags(DSH_ALLOWDROPDESCRIPTIONTEXT.0.cast_unsigned()) };
         let shdi = create_drag_image(image_bytes, cursor_offset)?;
         // InitializeFromBitmap takes ownership of shdi.hbmpDragImage on success; on failure the helper
         // does not take it, so free it here. This is the only manual cleanup point for the bitmap.
@@ -236,8 +239,9 @@ mod tests {
     fn initialize_from_bitmap_accepts_our_data_object() {
         ensure_com_initialized();
         let data_object: IDataObject = DataObject::new().into();
-        let helper: IDragSourceHelper =
+        let helper: IDragSourceHelper2 =
             unsafe { CoCreateInstance(&CLSID_DragDropHelper, None, CLSCTX_INPROC_SERVER) }.expect("create drag-drop helper");
+        unsafe { helper.SetFlags(DSH_ALLOWDROPDESCRIPTIONTEXT.0.cast_unsigned()) }.expect("SetFlags");
         let shdi = create_drag_image(&TEST_PNG_3X2, PhysicalPoint::new(0, 0)).expect("create drag image");
         let result = unsafe { helper.InitializeFromBitmap(&raw const shdi, &data_object) };
         assert!(result.is_ok(), "InitializeFromBitmap failed: {result:?}");

--- a/native/desktop-win32/src/win32/drag_drop_api.rs
+++ b/native/desktop-win32/src/win32/drag_drop_api.rs
@@ -1,10 +1,11 @@
-use desktop_common::logger::ffi_boundary;
+use desktop_common::{ffi_utils::BorrowedArray, logger::ffi_boundary};
 
 use windows::Win32::System::Com::IDataObject;
 
 use super::{
     com::ComInterfaceRawPtr,
     drag_drop::{DragSourceCallbacks, DropTargetCallbacks, register_drop_target, revoke_drop_target, start_drag_drop},
+    geometry::PhysicalPoint,
     window_api::{WindowPtr, with_window},
 };
 
@@ -16,10 +17,19 @@ pub extern "C" fn drag_drop_register_target(window_ptr: WindowPtr, callbacks: Dr
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn drag_drop_start(data_object: ComInterfaceRawPtr, allowed_effects: u32, callbacks: DragSourceCallbacks) -> u32 {
+pub extern "C" fn drag_drop_start(
+    data_object: ComInterfaceRawPtr,
+    allowed_effects: u32,
+    drag_image_bytes: BorrowedArray<u8>,
+    drag_image_offset: PhysicalPoint,
+    callbacks: DragSourceCallbacks,
+) -> u32 {
     ffi_boundary("drag_drop_start", || {
         let data_object = data_object.cast::<IDataObject>()?;
-        start_drag_drop(&data_object, allowed_effects, callbacks)
+        // A null drag_image_bytes array means "no custom drag image"; otherwise pair the bytes with
+        // the cursor offset.
+        let drag_image = drag_image_bytes.as_optional_slice().map(|bytes| (bytes, drag_image_offset));
+        start_drag_drop(&data_object, allowed_effects, drag_image, callbacks)
     })
 }
 

--- a/native/desktop-win32/src/win32/mod.rs
+++ b/native/desktop-win32/src/win32/mod.rs
@@ -36,5 +36,6 @@ pub mod strings;
 pub mod strings_api;
 pub mod system_menu;
 pub mod utils;
+pub mod wic_image;
 pub mod window;
 pub mod window_api;

--- a/native/desktop-win32/src/win32/wic_image.rs
+++ b/native/desktop-win32/src/win32/wic_image.rs
@@ -1,0 +1,225 @@
+use core::ffi::c_void;
+
+use anyhow::Context;
+use windows::Win32::{
+    Graphics::{
+        Gdi::{BI_RGB, BITMAPINFO, BITMAPINFOHEADER, CreateDIBSection, DIB_RGB_COLORS, DeleteObject, HBITMAP, HGDIOBJ},
+        Imaging::{
+            CLSID_WICImagingFactory, GUID_WICPixelFormat32bppBGRA, IWICImagingFactory, WICBitmapDitherTypeNone, WICBitmapPaletteTypeCustom,
+            WICDecodeMetadataCacheOnDemand,
+        },
+    },
+    System::Com::{CLSCTX_INPROC_SERVER, CoCreateInstance},
+};
+
+use super::geometry::PhysicalSize;
+
+// A decoded image as a top-down, straight (non-premultiplied) 32bpp BGRA DIB section. Owns the
+// bitmap and frees it on drop unless `into_handle` hands the handle off.
+pub(crate) struct WicBitmap {
+    bitmap: HBITMAP,
+    width: i32,
+    height: i32,
+}
+
+impl WicBitmap {
+    /// Decodes an encoded image into a top-down, straight-alpha 32bpp BGRA DIB section.
+    ///
+    /// Accepts any encoded image WIC can decode — the codec is selected by sniffing the stream, so
+    /// PNG, JPEG, BMP, GIF, TIFF, etc. all work. The result is a top-down DIB (negative `biHeight`)
+    /// with straight (non-premultiplied) BGRA, the layout the Shell drag-image helper expects.
+    pub(crate) fn decode_from_bytes(image_bytes: &[u8]) -> anyhow::Result<Self> {
+        // `InitializeFromMemory` borrows without copying; `image_bytes` outlives every stream/decoder
+        // use here (all of which happens before this function returns), so no owned copy is needed.
+        let factory: IWICImagingFactory =
+            unsafe { CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER) }.context("WIC factory")?;
+
+        let stream = unsafe { factory.CreateStream() }.context("WIC stream")?;
+        unsafe { stream.InitializeFromMemory(image_bytes) }.context("WIC stream init")?;
+
+        let decoder = unsafe { factory.CreateDecoderFromStream(&stream, core::ptr::null(), WICDecodeMetadataCacheOnDemand) }
+            .context("image decode")?;
+        let frame = unsafe { decoder.GetFrame(0) }.context("image frame")?;
+
+        // Convert to straight (non-premultiplied) BGRA: the Shell drag-image helper multiplies the
+        // color channels by alpha itself, so premultiplying here would apply that step twice.
+        let converter = unsafe { factory.CreateFormatConverter() }.context("format converter")?;
+        unsafe {
+            converter.Initialize(
+                &frame,
+                &GUID_WICPixelFormat32bppBGRA,
+                WICBitmapDitherTypeNone,
+                None,
+                0.0,
+                WICBitmapPaletteTypeCustom,
+            )
+        }
+        .context("format converter init")?;
+
+        let (mut width, mut height) = (0u32, 0u32);
+        unsafe { converter.GetSize(&raw mut width, &raw mut height) }.context("image size")?;
+        anyhow::ensure!(width != 0 && height != 0, "image has a zero dimension");
+        // Stride is the byte length of one pixel row: 4 bytes per pixel for 32bpp BGRA. A 32bpp row
+        // is inherently DWORD-aligned, so the DIB needs no extra end-of-row padding.
+        let stride = width.checked_mul(4).context("stride overflow")?;
+        let buf_len = (stride as usize).checked_mul(height as usize).context("pixel buffer overflow")?;
+        // The BITMAPINFOHEADER takes the dimensions as i32.
+        let width_i32 = i32::try_from(width)?;
+        let height_i32 = i32::try_from(height)?;
+
+        // Top-down (negative height) 32bpp BI_RGB DIB: the Shell drag-image helper expects top-down.
+        let bmi = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: size_of::<BITMAPINFOHEADER>().try_into()?,
+                biWidth: width_i32,
+                biHeight: -height_i32,
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: BI_RGB.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut bits: *mut c_void = core::ptr::null_mut();
+        let bitmap = unsafe { CreateDIBSection(None, &raw const bmi, DIB_RGB_COLORS, &raw mut bits, None, 0) }.context("DIB section")?;
+        // From here the returned value owns the bitmap and frees it on any early return below.
+        let image = Self {
+            bitmap,
+            width: width_i32,
+            height: height_i32,
+        };
+        anyhow::ensure!(!bits.is_null(), "DIB section has no backing memory");
+
+        // Copy the converted pixels into the DIB.
+        unsafe {
+            converter.CopyPixels(
+                core::ptr::null(),
+                stride,
+                core::slice::from_raw_parts_mut(bits.cast::<u8>(), buf_len),
+            )
+        }
+        .context("copy pixels into DIB")?;
+
+        Ok(image)
+    }
+
+    // Release ownership without freeing: the handle now belongs to the caller (e.g. an `SHDRAGIMAGE`).
+    pub(crate) const fn into_handle(self) -> HBITMAP {
+        let handle = self.bitmap;
+        core::mem::forget(self);
+        handle
+    }
+
+    // The image's size in physical pixels.
+    pub(crate) const fn size(&self) -> PhysicalSize {
+        PhysicalSize::new(self.width, self.height)
+    }
+}
+
+impl Drop for WicBitmap {
+    fn drop(&mut self) {
+        let _ = unsafe { DeleteObject(HGDIOBJ(self.bitmap.0)) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows::Win32::{
+        Foundation::{RPC_E_CHANGED_MODE, S_FALSE},
+        Graphics::Gdi::{DIBSECTION, GetObjectW},
+        System::Com::{COINIT_MULTITHREADED, CoInitializeEx},
+    };
+
+    // 2x2 RGBA PNG. Top-down reading order:
+    //   (0,0) half-transparent red   RGBA = (255,   0,   0, 128)
+    //   (1,0) opaque green           RGBA = (  0, 255,   0, 255)
+    //   (0,1) opaque blue            RGBA = (  0,   0, 255, 255)
+    //   (1,1) fully transparent white RGBA = (255, 255, 255,   0)
+    // The half-transparent red and fully-transparent white pixels distinguish straight from
+    // premultiplied BGRA.
+    const TEST_PNG_2X2: [u8; 79] = [
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+        0x00, 0x02, 0x08, 0x06, 0x00, 0x00, 0x00, 0x72, 0xb6, 0x0d, 0x24, 0x00, 0x00, 0x00, 0x16, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63,
+        0xf8, 0xcf, 0xc0, 0xd0, 0xc0, 0xf0, 0x1f, 0x08, 0x19, 0x18, 0xfe, 0x83, 0x00, 0x03, 0x00, 0x41, 0xd7, 0x08, 0x79, 0x08, 0xed, 0x0b,
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    fn ensure_com_initialized() {
+        // Cargo unit tests have no `OleInitialize`; production relies on application.rs. Tolerate the
+        // "already initialized" returns so repeated tests on one thread don't fail.
+        let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        assert!(
+            hr.is_ok() || hr == S_FALSE || hr == RPC_E_CHANGED_MODE,
+            "CoInitializeEx failed: {hr:?}"
+        );
+    }
+
+    fn read_dibsection(bitmap: HBITMAP) -> DIBSECTION {
+        let mut dib = DIBSECTION::default();
+        let written = unsafe {
+            GetObjectW(
+                HGDIOBJ(bitmap.0),
+                size_of::<DIBSECTION>().try_into().unwrap(),
+                Some((&raw mut dib).cast()),
+            )
+        };
+        assert_eq!(
+            usize::try_from(written).unwrap(),
+            size_of::<DIBSECTION>(),
+            "GetObjectW did not fill a DIBSECTION"
+        );
+        dib
+    }
+
+    #[test]
+    fn decode_from_bytes_matches_image_dimensions() {
+        ensure_com_initialized();
+        let dib = WicBitmap::decode_from_bytes(&TEST_PNG_2X2).unwrap();
+        assert_eq!(dib.size(), PhysicalSize::new(2, 2));
+    }
+
+    #[test]
+    fn decode_from_bytes_is_32bpp() {
+        ensure_com_initialized();
+        let dib = WicBitmap::decode_from_bytes(&TEST_PNG_2X2).unwrap();
+        let section = read_dibsection(dib.bitmap);
+        assert_eq!(section.dsBmih.biBitCount, 32);
+    }
+
+    #[test]
+    fn decode_from_bytes_lays_out_top_down() {
+        ensure_com_initialized();
+        let dib = WicBitmap::decode_from_bytes(&TEST_PNG_2X2).unwrap();
+        let section = read_dibsection(dib.bitmap);
+        // GetObjectW reports `dsBmih.biHeight` as the absolute height, so orientation is only
+        // observable from pixel memory. For 2x2 @ 32bpp the row stride is 8 bytes; in a top-down DIB
+        // the first scanline is the top row (half-transparent red) and the second is the bottom row
+        // (opaque blue), distinct in BGRA — a bottom-up DIB would swap them.
+        let pixels = unsafe { core::slice::from_raw_parts(section.dsBm.bmBits.cast::<u8>(), 16) };
+        let top_left = [pixels[0], pixels[1], pixels[2], pixels[3]];
+        let bottom_left = [pixels[8], pixels[9], pixels[10], pixels[11]];
+        assert_eq!(top_left, [0, 0, 255, 128], "first scanline must be the top row");
+        assert_eq!(bottom_left, [255, 0, 0, 255], "second scanline must be the bottom row");
+    }
+
+    #[test]
+    fn decode_from_bytes_keeps_straight_alpha() {
+        ensure_com_initialized();
+        let dib = WicBitmap::decode_from_bytes(&TEST_PNG_2X2).unwrap();
+        let section = read_dibsection(dib.bitmap);
+        // Sample the bottom-right pixel (fully transparent white, RGBA 255,255,255,0). Straight BGRA
+        // keeps the color channels at full intensity; premultiplied alpha (×0) would zero them all.
+        // It sits at row 1, column 1: byte offset stride(8) + 4 = 12.
+        let pixels = unsafe { core::slice::from_raw_parts(section.dsBm.bmBits.cast::<u8>(), 16) };
+        let bottom_right = [pixels[12], pixels[13], pixels[14], pixels[15]];
+        assert_eq!(bottom_right, [255, 255, 255, 0], "expected straight (non-premultiplied) BGRA");
+    }
+
+    #[test]
+    fn decode_from_bytes_with_invalid_bytes_returns_err() {
+        ensure_com_initialized();
+        let result = WicBitmap::decode_from_bytes(&[0u8, 1, 2, 3, 4, 5, 6, 7]);
+        assert!(result.is_err());
+    }
+}

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoSampleWin32.kt
@@ -120,7 +120,7 @@ class ApplicationState(private val app: Application) : AutoCloseable {
             window.setImmersiveDarkMode(true)
         }
 
-//        window.initializeDropManager()
+        window.initializeDropManager()
     }
 
     fun handleEvent(event: Event, windowId: WindowId): EventHandlerResult {

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/win32/SkikoWindowWin32.kt
@@ -14,6 +14,7 @@ import org.jetbrains.desktop.win32.DragDropEffect
 import org.jetbrains.desktop.win32.DragDropManager
 import org.jetbrains.desktop.win32.DragDropModifier
 import org.jetbrains.desktop.win32.DragDropModifiers
+import org.jetbrains.desktop.win32.DragImage
 import org.jetbrains.desktop.win32.DragSource
 import org.jetbrains.desktop.win32.DropTarget
 import org.jetbrains.desktop.win32.Event
@@ -34,12 +35,19 @@ import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Font
+import org.jetbrains.skia.FontMgr
+import org.jetbrains.skia.FontStyle
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.RRect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skia.makeGLWithInterface
+import kotlin.math.ceil
 import kotlin.time.TimeSource
 
 abstract class SkikoWindowWin32(private val app: Application) : AutoCloseable {
@@ -258,9 +266,10 @@ abstract class SkikoWindowWin32(private val app: Application) : AutoCloseable {
                     !nonClientArea &&
                     state.pressedButtons.hasFlag(PointerButton.Left)
                 ) {
+                    val dragText = "Hello drag and drop!"
                     DataObject.build {
                         addHtmlFragment("<b>HTML</b> <i>fragment</i>")
-                        addTextItem("Hello drag and drop!")
+                        addTextItem(dragText)
                     }.use { dataObject ->
                         val dragSource = object : DragSource {
                             override fun onQueryContinueDrag(escapePressed: Boolean, modifiers: DragDropModifiers): DragDropContinueResult {
@@ -276,7 +285,8 @@ abstract class SkikoWindowWin32(private val app: Application) : AutoCloseable {
                                 }
                             }
                         }
-                        dragDropManager?.doDragDrop(dataObject, DragDropEffect.Copy, dragSource)
+                        val dragImage = renderDragImage(dragText)
+                        dragDropManager?.doDragDrop(dataObject, DragDropEffect.Copy, dragSource, dragImage)
                         Logger.debug { "Drag finished" }
                     }
                 }
@@ -405,6 +415,45 @@ abstract class SkikoWindowWin32(private val app: Application) : AutoCloseable {
                 surface.flushAndSubmit()
                 angleRenderer.swapBuffers()
             }
+        }
+    }
+
+    /**
+     * Renders a rounded-rectangle badge carrying [text] to an offscreen raster surface via Skiko and
+     * encodes it as a PNG for use as the drag image under the cursor, sized to the current DPI. A
+     * raster surface needs no GL context, so this runs on the STA thread the drag starts on (unlike
+     * [performDrawing], which draws through ANGLE).
+     */
+    private fun renderDragImage(text: String): DragImage {
+        val scale = window.getScaleFactor()
+        val paddingX = 14f * scale
+        val paddingY = 10f * scale
+
+        // "Segoe UI" is the Windows UI font; DirectWrite does not resolve the generic "sans-serif" name.
+        val typeface = requireNotNull(FontMgr.default.matchFamilyStyle("Segoe UI", FontStyle.NORMAL)) {
+            "Segoe UI font is unavailable"
+        }
+
+        return Font(typeface, 12f * scale).use { font ->
+            val metrics = font.metrics
+            val width = ceil(font.measureTextWidth(text) + paddingX * 2).toInt().coerceAtLeast(1)
+            val height = ceil((metrics.descent - metrics.ascent) + paddingY * 2).toInt().coerceAtLeast(1)
+
+            val png = Surface.makeRasterN32Premul(width, height).use { surface ->
+                val canvas = surface.canvas
+                canvas.clear(Color.TRANSPARENT)
+                Paint().use { paint ->
+                    paint.isAntiAlias = true
+                    paint.color = 0xE61F1F1F.toInt() // translucent dark backplate
+                    canvas.drawRRect(RRect.makeXYWH(0f, 0f, width.toFloat(), height.toFloat(), 8f * scale), paint)
+                    paint.color = Color.WHITE
+                    canvas.drawString(text, paddingX, paddingY - metrics.ascent, font, paint)
+                }
+                surface.makeImageSnapshot().use { it.encodeToData(EncodedImageFormat.PNG)!!.bytes }
+            }
+
+            // Anchor the cursor near the left edge so the badge trails the pointer like a dragged item.
+            DragImage(png, PhysicalPoint((16f * scale).toInt(), height / 2))
         }
     }
 


### PR DESCRIPTION
## What

Adds **custom drag-image support** to the `desktop-win32` drag-and-drop subsystem, in both directions:

- **Source side** — when the app starts a drag, it can supply a custom image (encoded bytes, e.g. PNG + a cursor offset) that follows the cursor for the whole operation.
- **Target side** — when the app is a drop target, the OS-provided drag image (e.g. a file dragged from Explorer) now renders correctly while the cursor is over our window.

Both use the Shell drag-and-drop helper (`CLSID_DragDropHelper`): `IDragSourceHelper2` on the source, `IDropTargetHelper` on the target.

## Why

The toolkit previously offered no drag-image affordance on Windows — a source drag showed only the default cursor, and OS drag images did not render over our drop targets. Custom drag visuals are table stakes for a desktop UI toolkit.

## How it works

- **`DataObject::SetData` / `GetData` (the enabling change).** The Shell drag-image helper stores its private, cross-process formats into the data object via `SetData` and reads them back via `GetData` — so `SetData` (previously `E_NOTIMPL`) had to work. It now accepts `TYMED_HGLOBAL` (contents copied into an owned HGLOBAL) and `TYMED_ISTREAM`. A stream is **retained as an agile reference** (`RoGetAgileReference`) and served back as `TYMED_ISTREAM` — *not* byte-copied — because the helper's `DragContext` stream must be readable by a peer process's drag-image manager. `GetData`/`QueryGetData` return granular `DV_E_FORMATETC` / `DV_E_DVASPECT` / `DV_E_TYMED`, and `EnumFormatEtc` advertises each format's real medium. The backing store is now `papaya::HashMap<u32, StoredMedium>` (`HGlobal(HGlobalData)` | `Stream(IAgileReference)`). The clipboard path (which never calls `SetData`) is unaffected.
- **Image decode (`wic_image.rs`, new).** `WicBitmap::decode_from_bytes` decodes any WIC-supported image to a top-down, straight (non-premultiplied) 32bpp BGRA DIB via a `CreateDIBSection` + `CopyPixels` pipeline. Straight alpha is required — `InitializeFromBitmap` re-multiplies by alpha itself. RAII: the bitmap is freed on drop unless `into_handle()` hands it off.
- **Source wiring.** `start_drag_drop` creates an `IDragSourceHelper2`, opts into `DSH_ALLOWDROPDESCRIPTIONTEXT` (so a drop target's drop-description text renders over the custom image), then calls `InitializeFromBitmap` before `DoDragDrop`. The helper takes ownership of the `HBITMAP` on success; we free it only on failure.
- **Target wiring (internal).** `DropTarget` holds an `Option<IDropTargetHelper>` created at registration and forwards each `IDropTarget` method to it (with the screen-coord `POINT` and the app-resolved effect). Helper failures are cosmetic and swallowed — they never change the drop result.
- **FFI + Kotlin API.** `drag_drop_start` gains flat params — `drag_image_bytes: BorrowedArray<u8>` + `drag_image_offset: PhysicalPoint` — a null byte array meaning "no image" (the codebase's sentinel convention). The public `DragDropManager.doDragDrop` gains an optional `dragImage: DragImage? = null` (default keeps existing call sites source-compatible); the sample demonstrates it.

## Testing

- `cargo test -p desktop-win32` — **52 pass**; `cargo clippy --all-targets -- -D warnings` clean.
- Independent adversarial review of the branch: no Critical/Important findings. Verified the agile `IStream` refcounting, HBITMAP ownership, the OLE `SetData` `fRelease` contract (release only on success — never on error, so no double-free), the top-down straight-BGRA DIB, and the FFI ↔ Kotlin ABI.
- **Manual cross-process drag confirmed** by the author: the source image follows the cursor into other apps and on re-entry; OS drag images render over our drop target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
