### PR TITLE
fix(win32): enum formats in a data object when checking for availability

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataObject.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/win32/DataObject.kt
@@ -45,6 +45,16 @@ public class DataObject(private var comInterfacePtr: MemorySegment) : AutoClosea
         formatIds.map(DataFormat::fromNative)
     }
 
+    public fun canReadItemOfType(format: DataFormat): Boolean = requireOpen { ptr ->
+        Arena.ofConfined().use { arena ->
+            val result = ffiDownCall {
+                desktop_win32_h.com_data_object_query_get_data_result(arena, ptr, format.id)
+            }
+            val operation = dataTransferOperationFromNative(result)
+            operation.requireOkOrUnavailable()
+        }
+    }
+
     public fun readItemOfType(format: DataFormat): ByteArray = requireOpen { ptr ->
         Arena.ofConfined().use { arena ->
             val result = ffiDownCall {

--- a/native/desktop-win32/src/win32/data_object.rs
+++ b/native/desktop-win32/src/win32/data_object.rs
@@ -5,9 +5,7 @@ use std::mem::ManuallyDrop;
 
 use anyhow::Context;
 use windows::Win32::{
-    Foundation::{
-        DV_E_DVASPECT, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
-    },
+    Foundation::{DV_E_DVASPECT, DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, E_POINTER, E_UNEXPECTED, HANDLE, OLE_E_ADVISENOTSUPPORTED, S_OK},
     System::{
         Com::{
             DATADIR, DATADIR_GET, DVASPECT_CONTENT, FORMATETC, IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
@@ -213,16 +211,7 @@ impl IDataObject_Impl for DataObject_Impl {
     }
 }
 
-pub fn is_data_object_format_available(data_object: &IDataObject, data_format: DataFormat) -> anyhow::Result<bool> {
-    let format_etc = get_format_etc_for_supported_tymeds(data_format);
-    match unsafe { data_object.QueryGetData(&raw const format_etc) } {
-        S_OK => Ok(true),
-        S_FALSE | DV_E_FORMATETC | DV_E_TYMED => Ok(false),
-        result => Err(WinError::from(result).into()),
-    }
-}
-
-pub fn enum_data_object_format_ids(data_object: &IDataObject) -> anyhow::Result<Box<[u32]>> {
+pub fn enum_data_object_format_ids(data_object: &IDataObject) -> anyhow::Result<std::collections::HashSet<u32>> {
     let iter = unsafe { data_object.EnumFormatEtc(DATADIR_GET.0.cast_unsigned())? };
     let mut hash_set = std::collections::HashSet::new();
     let mut formats = [FORMATETC::default(); 1];
@@ -235,7 +224,7 @@ pub fn enum_data_object_format_ids(data_object: &IDataObject) -> anyhow::Result<
             hash_set.insert(u32::from(format_etc.cfFormat));
         }
     }
-    Ok(hash_set.into_iter().collect())
+    Ok(hash_set)
 }
 
 /// Returns a `FORMATETC` requesting `data_format` in any `TYMED` the data-transfer path handles —
@@ -529,17 +518,6 @@ mod tests {
     }
 
     #[test]
-    fn is_data_object_format_available_reflects_presence() {
-        let data_object = ComObject::new(DataObject::new());
-        let data = hglobal_writer::new_bytes(b"payload").unwrap();
-        assert!(data_object.add_format(DataFormat::Other(CUSTOM_FORMAT), data));
-        let iface: IDataObject = data_object.to_interface();
-
-        assert!(super::is_data_object_format_available(&iface, DataFormat::Other(CUSTOM_FORMAT)).unwrap());
-        assert!(!super::is_data_object_format_available(&iface, DataFormat::Other(UNKNOWN_FORMAT)).unwrap());
-    }
-
-    #[test]
     fn set_data_with_null_medium_returns_e_pointer() {
         let data_object: IDataObject = DataObject::new().into();
         let format_etc = get_format_etc_for_hglobal(DataFormat::Other(CUSTOM_FORMAT));
@@ -563,15 +541,6 @@ mod tests {
         unsafe { data_object.SetData(&raw const format_etc, &raw const second_medium, false) }.unwrap();
 
         assert_eq!(read_get_data_bytes(&data_object, CUSTOM_FORMAT), b"second");
-    }
-
-    #[test]
-    fn is_data_object_format_available_true_for_stream_format() {
-        // The availability query spans HGLOBAL and ISTREAM, so a stream-only format reads as present.
-        let data_object: IDataObject = DataObject::new().into();
-        set_istream_format(&data_object, CUSTOM_FORMAT, b"stream-payload");
-
-        assert!(super::is_data_object_format_available(&data_object, DataFormat::Other(CUSTOM_FORMAT)).unwrap());
     }
 
     #[test]

--- a/native/desktop-win32/src/win32/data_object_api.rs
+++ b/native/desktop-win32/src/win32/data_object_api.rs
@@ -13,7 +13,7 @@ use windows_core::ComObject;
 
 use super::{
     com::ComInterfaceRawPtr,
-    data_object::{DataObject, enum_data_object_format_ids, is_data_object_format_available},
+    data_object::{DataObject, enum_data_object_format_ids},
     data_reader::DataReader,
     data_transfer::{
         DataFormat, DataTransferBoolResult, DataTransferByteArrayResult, DataTransferStringArrayResult, DataTransferStringResult,
@@ -113,7 +113,8 @@ pub extern "C" fn com_data_object_is_format_available_result(
 ) -> DataTransferBoolResult {
     data_transfer_boundary("com_data_object_is_format_available_result", || {
         let data_object = data_object_ptr.cast::<IDataObject>()?;
-        is_data_object_format_available(&data_object, DataFormat::Other(data_format))
+        let formats = enum_data_object_format_ids(&data_object)?;
+        Ok(formats.contains(&data_format))
     })
 }
 
@@ -122,7 +123,7 @@ pub extern "C" fn com_data_object_enum_formats_result(data_object_ptr: ComInterf
     data_transfer_boundary("com_data_object_enum_formats_result", || {
         let data_object = data_object_ptr.cast::<IDataObject>()?;
         let formats = enum_data_object_format_ids(&data_object)?;
-        Ok(AutoDropArray::new(formats))
+        Ok(AutoDropArray::new(formats.into_iter().collect()))
     })
 }
 

--- a/native/desktop-win32/src/win32/data_object_api.rs
+++ b/native/desktop-win32/src/win32/data_object_api.rs
@@ -8,16 +8,16 @@ use std::sync::{
 };
 
 use anyhow::Context;
-use windows::Win32::System::Com::IDataObject;
+use windows::Win32::{Foundation::S_FALSE, System::Com::IDataObject};
 use windows_core::ComObject;
 
 use super::{
     com::ComInterfaceRawPtr,
-    data_object::{DataObject, enum_data_object_format_ids},
+    data_object::{DataObject, enum_data_object_format_ids, get_format_etc_for_supported_tymeds},
     data_reader::DataReader,
     data_transfer::{
-        DataFormat, DataTransferBoolResult, DataTransferByteArrayResult, DataTransferStringArrayResult, DataTransferStringResult,
-        DataTransferUInt32ArrayResult, data_transfer_boundary,
+        DataFormat, DataTransferBoolResult, DataTransferByteArrayResult, DataTransferFailure, DataTransferOperationResult,
+        DataTransferStringArrayResult, DataTransferStringResult, DataTransferUInt32ArrayResult, data_transfer_boundary,
     },
     global_data::hglobal_writer,
     strings::copy_from_utf8_string,
@@ -124,6 +124,22 @@ pub extern "C" fn com_data_object_enum_formats_result(data_object_ptr: ComInterf
         let data_object = data_object_ptr.cast::<IDataObject>()?;
         let formats = enum_data_object_format_ids(&data_object)?;
         Ok(AutoDropArray::new(formats.into_iter().collect()))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn com_data_object_query_get_data_result(
+    data_object_ptr: ComInterfaceRawPtr,
+    data_format: u32,
+) -> DataTransferOperationResult {
+    data_transfer_boundary("com_data_object_query_get_data_result", || {
+        let data_object = data_object_ptr.cast::<IDataObject>()?;
+        let format_etc = get_format_etc_for_supported_tymeds(DataFormat::Other(data_format));
+        match unsafe { data_object.QueryGetData(&raw const format_etc) } {
+            S_FALSE => anyhow::bail!(DataTransferFailure::format_unavailable(data_format)),
+            hr => hr.ok()?,
+        }
+        Ok(())
     })
 }
 

--- a/native/desktop-win32/src/win32/data_transfer.rs
+++ b/native/desktop-win32/src/win32/data_transfer.rs
@@ -155,6 +155,15 @@ impl DataTransferFailure {
     }
 
     #[must_use]
+    pub fn format_unavailable(format_id: u32) -> Self {
+        Self {
+            status: DataTransferStatus::FormatUnavailable,
+            code: 0,
+            message: format!("requested format is unavailable: {format_id}"),
+        }
+    }
+
+    #[must_use]
     pub fn invalid_data(message: impl Into<String>) -> Self {
         Self::invalid_data_with_code(0, message)
     }


### PR DESCRIPTION
Fixes [AIR-6051](https://youtrack.jetbrains.com/issue/AIR-6051) Dragging a Firefox tab into Air causes both applications to freeze (Windows)