### PR TITLE
feat(macos): expose traffic light buttons inset for custom titlebar

### DIFF
--- a/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Window.kt
+++ b/kotlin-desktop-toolkit/src/main/kotlin/org/jetbrains/desktop/macos/Window.kt
@@ -334,6 +334,20 @@ public class Window internal constructor(
         }
     }
 
+    /**
+     * Returns the horizontal space taken by the traffic light button block, measured from
+     * the window's left edge. This spans from the left edge to the right edge of the
+     * rightmost button, plus symmetric trailing padding equal to the leading gap between
+     * the window edge and the first button — so content laid out at this inset is padded
+     * away from the buttons by the same amount the buttons are padded from the window edge.
+     *
+     * Returns 0 when the window uses the regular titlebar (see [TitlebarConfiguration])
+     * or is in full screen.
+     */
+    public fun getTitlebarLeftInset(): LogicalPixels {
+        return ffiDownCall { desktop_macos_h.window_get_titlebar_left_inset(pointer) }
+    }
+
     public var overriddenAppearance: Appearance?
         get() {
             return if (ffiDownCall { desktop_macos_h.window_appearance_is_overridden(pointer) }) {

--- a/kotlin-desktop-toolkit/src/test/kotlin/org/jetbrains/desktop/macos/tests/TitlebarTests.kt
+++ b/kotlin-desktop-toolkit/src/test/kotlin/org/jetbrains/desktop/macos/tests/TitlebarTests.kt
@@ -1,12 +1,16 @@
 package org.jetbrains.desktop.macos.tests
 
+import org.jetbrains.desktop.macos.Event
 import org.jetbrains.desktop.macos.LogicalSize
 import org.jetbrains.desktop.macos.TitlebarConfiguration
 import org.jetbrains.desktop.macos.Window
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @EnabledOnOs(OS.MAC)
 class TitlebarTests : KDTApplicationTestBase() {
@@ -80,6 +84,78 @@ class TitlebarTests : KDTApplicationTestBase() {
             assertEquals(initialSize, window.size, "Window size should be preserved after switching to custom titlebar")
         }
         ui {
+            window.close()
+        }
+    }
+
+    @Test
+    fun `left inset is zero for regular titlebar`() {
+        val window = ui {
+            Window.create(titlebarConfiguration = TitlebarConfiguration.Regular)
+        }
+        ui {
+            assertEquals(0.0, window.getTitlebarLeftInset(), "Left inset should be zero for the regular titlebar")
+            window.close()
+        }
+    }
+
+    @Test
+    fun `left inset is positive for custom titlebar`() {
+        val window = ui {
+            Window.create(titlebarConfiguration = TitlebarConfiguration.Custom(titlebarHeight = 42.0))
+        }
+        ui {
+            val leftInset = window.getTitlebarLeftInset()
+            assertTrue(leftInset > 0.0, "Left inset should be positive for a custom titlebar, got $leftInset")
+            window.close()
+        }
+    }
+
+    @Test
+    fun `left inset updates on titlebar configuration switch`() {
+        val window = ui {
+            Window.create(titlebarConfiguration = TitlebarConfiguration.Regular)
+        }
+        ui {
+            assertEquals(0.0, window.getTitlebarLeftInset(), "Left inset should be zero before switching to custom titlebar")
+
+            window.setTitlebarConfiguration(TitlebarConfiguration.Custom(titlebarHeight = 42.0))
+            val leftInset = window.getTitlebarLeftInset()
+            assertTrue(leftInset > 0.0, "Left inset should be positive after switching to custom titlebar, got $leftInset")
+
+            window.setTitlebarConfiguration(TitlebarConfiguration.Regular)
+            assertEquals(0.0, window.getTitlebarLeftInset(), "Left inset should be zero after switching back to regular titlebar")
+
+            window.close()
+        }
+    }
+
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @Test
+    fun `left inset is zero in full screen`() {
+        val window = ui {
+            Window.create(titlebarConfiguration = TitlebarConfiguration.Custom(titlebarHeight = 42.0))
+        }
+        ui {
+            window.makeKeyAndOrderFront()
+        }
+        awaitEventOfType<Event.WindowChangedOcclusionState> { it.windowId == window.windowId() && it.isVisible }
+
+        ui {
+            window.toggleFullScreen()
+        }
+        awaitEventOfType<Event.WindowFullScreenToggle> { it.windowId == window.windowId() && it.isFullScreen }
+        ui {
+            assertEquals(0.0, window.getTitlebarLeftInset(), "Left inset should be zero in full screen")
+        }
+
+        ui {
+            window.toggleFullScreen()
+        }
+        awaitEventOfType<Event.WindowFullScreenToggle> { it.windowId == window.windowId() && !it.isFullScreen }
+        ui {
+            val leftInset = window.getTitlebarLeftInset()
+            assertTrue(leftInset > 0.0, "Left inset should be positive after exiting full screen, got $leftInset")
             window.close()
         }
     }

--- a/native/desktop-macos/src/macos/titlebar.rs
+++ b/native/desktop-macos/src/macos/titlebar.rs
@@ -65,6 +65,19 @@ impl Titlebar {
         }
     }
 
+    pub(crate) fn left_inset(&self) -> anyhow::Result<LogicalPixels> {
+        match &self.state {
+            TitlebarState::Regular => Ok(0.0),
+            TitlebarState::Custom(..) => {
+                if self.ns_window.styleMask().contains(NSWindowStyleMask::FullScreen) {
+                    return Ok(0.0);
+                }
+                let titlebar_views = unsafe { TitlebarViews::retrieve_from_window(&self.ns_window) }?;
+                Ok(titlebar_views.buttons_block_width())
+            }
+        }
+    }
+
     pub(crate) fn before_enter_fullscreen(&mut self) {
         if let TitlebarState::Custom(ref mut state) = self.state {
             state.deactivate_constraints(&self.ns_window).unwrap();
@@ -219,6 +232,24 @@ impl TitlebarViews {
 
         // theme frame should keep follow autoresizing mask to match window constraints
         // self.theme_frame.setTranslatesAutoresizingMaskIntoConstraints(value);
+    }
+
+    // Horizontal space taken by the whole traffic light button block, including
+    // padding. Button frames are relative to the titlebar view, whose left edge is
+    // pinned to the window's left edge, so the leading gap between the window edge
+    // and the first button is mirrored after the last button to keep the block
+    // symmetrically padded.
+    fn buttons_block_width(&self) -> LogicalPixels {
+        let buttons = [&self.close_button, &self.miniaturize_button, &self.zoom_button];
+        let leading_padding = buttons.iter().map(|button| button.frame().origin.x).fold(f64::INFINITY, f64::min);
+        let right_edge = buttons
+            .iter()
+            .map(|button| {
+                let frame = button.frame();
+                frame.origin.x + frame.size.width
+            })
+            .fold(0.0, f64::max);
+        right_edge + leading_padding
     }
 
     fn horizontal_button_offset(titlebar_height: LogicalPixels) -> LogicalPixels {

--- a/native/desktop-macos/src/macos/window_api.rs
+++ b/native/desktop-macos/src/macos/window_api.rs
@@ -76,6 +76,15 @@ pub extern "C" fn window_set_titlebar_configuration(window_ptr: WindowPtr, mode:
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn window_get_titlebar_left_inset(window_ptr: WindowPtr) -> LogicalPixels {
+    ffi_boundary("window_get_titlebar_left_inset", || {
+        let _mtm: MainThreadMarker = MainThreadMarker::new().unwrap();
+        let window = unsafe { window_ptr.borrow::<Window>() };
+        window.titlebar.borrow().left_inset()
+    })
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn window_get_window_id(window_ptr: WindowPtr) -> WindowId {
     ffi_boundary("window_get_window_id", || {
         let window = unsafe { window_ptr.borrow::<Window>() };

--- a/sample/src/main/kotlin/org/jetbrains/desktop/sample/macos/SkikoSampleMac.kt
+++ b/sample/src/main/kotlin/org/jetbrains/desktop/sample/macos/SkikoSampleMac.kt
@@ -60,6 +60,11 @@ class CustomTitlebar(
     var startWindowDrag: (() -> Unit)? = null,
     var zoomBoxClicked: (() -> Unit)? = null,
 ) {
+    // Horizontal space taken by the traffic light buttons, reported by the window.
+    // Updated before every frame so the marker rectangle stays in sync when the
+    // titlebar height changes or the window enters/exits full screen.
+    var leftInset: LogicalPixels = 0.0
+
     companion object {
         const val DEFAULT_CUSTOM_TITLEBAR_HEIGHT: LogicalPixels = 55.0
     }
@@ -124,6 +129,16 @@ class CustomTitlebar(
         Paint().use { paint ->
             paint.color = 0xFFAAAAAA.toInt()
             canvas.drawRect(Rect.makeXYWH(width * 0.75f, y, width * 0.25f, height), paint)
+        }
+
+        // Marker rectangle starting exactly at the left inset. Its left edge should
+        // line up with the right edge of the traffic light buttons, which visually
+        // verifies that the reported inset is correct.
+        Paint().use { paint ->
+            paint.color = 0xFFFF00FF.toInt()
+            val markerX = ((origin.x + leftInset) * scale).toFloat()
+            val markerWidth = (2.0 * scale).toFloat()
+            canvas.drawRect(Rect.makeXYWH(markerX, y, markerWidth, height), paint)
         }
 
         // Draw the color-changing square
@@ -393,6 +408,7 @@ class RotatingBallWindow(
     override fun Canvas.draw(size: PhysicalSize, time: Long) {
         val canvas = this
         // canvas.clear(Color.RED) // use RED to debug
+        windowContainer.customTitlebar?.leftInset = window.getTitlebarLeftInset()
         windowContainer.draw(canvas, time, window.scaleFactor())
         textInput.draw(canvas, window.scaleFactor())
     }


### PR DESCRIPTION
Add Window.getTitlebarLeftInset() backed by the native window_get_titlebar_left_inset FFI call. For a custom titlebar it returns the horizontal space taken by the traffic light button block, including symmetric padding mirrored after the buttons; it returns 0 for the regular titlebar and in full screen.

Draw a marker rectangle at the reported inset in the Skiko sample to visually verify the value, and cover the behavior with TitlebarTests.